### PR TITLE
Refactor block-diagonal sparse operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ train_data = gpx.Dataset(x_train, y_train)
 
 # Condition a CaGP with an (untrained) sparse linear solver policy
 key, subkey = jax.random.split(key)
-policy = cagpjax.policies.BlockSparsePolicy(n_actions=10, n=n_data, key=subkey)
+policy = cagpjax.policies.BlockSparsePolicy(n_data, n_actions=10, key=subkey)
 cagp = cagpjax.models.ComputationAwareGP(posterior, policy)
 
 # Optimize hyperparameters (including actions)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,10 +47,11 @@ nav:
   - Reference: reference/
 
 markdown_extensions:
+  - admonition
   - footnotes
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.superfences 
+  - pymdownx.superfences
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite

--- a/src/cagpjax/linalg/congruence.py
+++ b/src/cagpjax/linalg/congruence.py
@@ -23,23 +23,16 @@ def congruence_transform(A: Diagonal, B: Diagonal) -> Diagonal:  # pyright: igno
 
 
 @overload
-def congruence_transform(A: BlockDiagonalSparse, B: Diagonal | ScalarMul) -> Diagonal:  # pyright: ignore[reportOverlappingOverload]
-    nz_values = B @ A.nz_values**2
+def congruence_transform(A: BlockDiagonalSparse, B: Diagonal) -> Diagonal:  # pyright: ignore[reportOverlappingOverload]
+    n_used = A.nz_values.size
+    diag_values = cola.linalg.diag(B)[:n_used].reshape(A.nz_values.shape)
+    diag = jnp.sum(diag_values * jnp.square(A.nz_values), axis=1)
+    return Diagonal(diag)
 
-    n_blocks, n = A.shape
-    block_size = n // n_blocks
-    n_blocks_main = n_blocks if n % n_blocks == 0 else n_blocks - 1
-    n_main = n_blocks_main * block_size
 
-    if n_blocks_main > 0:
-        diag = nz_values[:n_main].reshape(n_blocks_main, block_size).sum(axis=1)
-    else:
-        diag = jnp.array([], dtype=nz_values.dtype)
-
-    if n > n_main:
-        overhang_sum = nz_values[n_main:].sum(axis=0, keepdims=True)
-        diag = jnp.concatenate([diag, overhang_sum])
-
+@overload
+def congruence_transform(A: BlockDiagonalSparse, B: ScalarMul) -> Diagonal:  # pyright: ignore[reportOverlappingOverload]
+    diag = jnp.sum(jnp.square(A.nz_values), axis=1) * B.c
     return Diagonal(diag)
 
 

--- a/src/cagpjax/operators/block_diagonal_sparse.py
+++ b/src/cagpjax/operators/block_diagonal_sparse.py
@@ -35,32 +35,18 @@ class BlockDiagonalSparse(LinearOperator):
 
     def __init__(self, nz_values: Float[Array, "N"], n_blocks: int):
         n = nz_values.shape[0]
+        block_size = n // n_blocks
+        n_used = n_blocks * block_size
         super().__init__(nz_values.dtype, (n_blocks, n))
-        self.nz_values = nz_values
+        self.nz_values = nz_values[:n_used].reshape(n_blocks, block_size)
 
     def _matmat(self, X: Float[Array, "N #M"]) -> Float[Array, "K #M"]:
-        # figure out size of main blocks
         n_blocks, n = self.shape
-        block_size = n // n_blocks
-        n_blocks_main = n_blocks if n % n_blocks == 0 else n_blocks - 1
-        n_main = n_blocks_main * block_size
+        n_used = self.nz_values.size
+        block_size = n_used // n_blocks
 
-        # block-wise multiplication for main blocks
-        if n_blocks_main > 0:
-            blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
-            X_main = X[:n_main, ...].reshape(n_blocks_main, block_size, -1)
-            res_main = jnp.einsum("ik,ikj->ij", blocks_main, X_main)
-        else:
-            res_main = jnp.empty((0, *X.shape[1:]), dtype=X.dtype)
-
-        # handle overhang if any
-        if n > n_main:
-            n_overhang = n - n_main
-            X_overhang = X[n_main:, ...].reshape(n_overhang, -1)
-            block_overhang = self.nz_values[n_main:]
-            res_overhang = block_overhang[None, :] @ X_overhang
-            res = jnp.concatenate([res_main, res_overhang], axis=0)
-        else:
-            res = res_main
+        # block-wise multiplication for used portion
+        X_used = X[:n_used, ...].reshape(n_blocks, block_size, -1)
+        res = jnp.einsum("ik,ikj->ij", self.nz_values, X_used)
 
         return res.reshape(-1, *X.shape[1:])

--- a/src/cagpjax/operators/block_diagonal_sparse.py
+++ b/src/cagpjax/operators/block_diagonal_sparse.py
@@ -46,7 +46,7 @@ class BlockDiagonalSparse(LinearOperator):
             raise ValueError(
                 f"n ({n}) must be >= n_blocks * block_size ({n_blocks * block_size})"
             )
-        super().__init__(nz_values.dtype, (n_blocks, n))
+        super().__init__(nz_values.dtype, (n, n_blocks), annotations={ScaledOrthogonal})
         self.nz_values = nz_values
 
     def _matmat(self, X: Float[Array, "N #M"]) -> Float[Array, "K #M"]:

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -22,57 +22,64 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
 
     $$
     S = \begin{bmatrix}
-        s_1 & 0 & \cdots & 0 \\
-        0 & s_2 & \cdots & 0 \\
-        \vdots & \vdots & \ddots & \vdots \\
-        0 & 0 & \cdots & s_{\text{n_actions}}
-    \end{bmatrix}
+        s_1 & 0 & \cdots & 0 & 0 \\
+        0 & s_2 & \cdots & 0 & 0 \\
+        \vdots & \vdots & \ddots & \vdots & \vdots \\
+        0 & 0 & \cdots & s_{\text{n_actions}} & 0 \\
+        0 & 0 & \cdots & 0 & 0
+    \end{bmatrix}.
     $$
+    This effectively ignores the last ``n % n_actions`` rows of data.
 
     These are stacked and stored as a single trainable parameter ``nz_values``.
+
+    !!! note
+        The last block is included if necessary to pad the first dimension of the matrix
+        to be equal to ``n``. This effectively ignores the last ``n % n_actions`` rows of data.
     """
 
     def __init__(
         self,
-        n_actions: int,
-        n: int | None = None,
-        nz_values: Float[Array, "N"] | nnx.Variable[Float[Array, "N"]] | None = None,
+        n: int,
+        nz_values: Float[Array, "n_actions block_size"]
+        | nnx.Variable[Float[Array, "n_actions block_size"]]
+        | None = None,
+        n_actions: int | None = None,
         key: PRNGKeyArray | None = None,
         **kwargs,
     ):
         """Initialize the block sparse policy.
 
         Args:
-            n_actions: Number of actions to use.
-            n: Number of rows and columns of the full operator. Must be provided if ``nz_values`` is
-                not provided.
-            nz_values: Non-zero values of the block-diagonal sparse matrix (shape ``(n,)``). If not
-                provided, random actions are sampled using the key if provided.
+            n: Number of rows and columns of the full operator.
+            nz_values: Non-zero values of the block-diagonal sparse matrix. If not
+                provided, random actions are sampled using the ``key``.
+            n_actions: Number of actions to use. Required if ``nz_values`` is not provided.
             key: Random key for sampling actions if ``nz_values`` is not provided.
             **kwargs: Additional keyword arguments for ``jax.random.normal`` (e.g. ``dtype``)
         """
         if nz_values is None:
-            if n is None:
-                raise ValueError("n must be provided if nz_values is not provided")
+            if n_actions is None:
+                raise ValueError(
+                    "n_actions must be provided if nz_values is not provided"
+                )
             if key is None:
                 key = jax.random.PRNGKey(0)
             block_size = n // n_actions
-            nz_values = jax.random.normal(key, (n,), **kwargs)
+            nz_values = jax.random.normal(key, (n_actions, block_size), **kwargs)
             nz_values /= jnp.sqrt(block_size)
-        elif n is not None:
-            warnings.warn("n is ignored because nz_values is provided")
 
         if not isinstance(nz_values, nnx.Variable):
             nz_values = Real(nz_values)
 
-        self.nz_values: nnx.Variable[Float[Array, "N"]] = nz_values
-        self._n_actions: int = n_actions
+        self.nz_values: nnx.Variable[Float[Array, "n_actions block_size"]] = nz_values
+        self._n: int = n
 
     @property
     @override
     def n_actions(self) -> int:
         """Number of actions to be used."""
-        return self._n_actions
+        return self.nz_values.value.shape[0]
 
     @override
     def to_actions(self, A: LinearOperator) -> LinearOperator:
@@ -84,4 +91,4 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         Returns:
             Transposed[BlockDiagonalSparse]: Sparse action structure representing the blocks.
         """
-        return BlockDiagonalSparse(self.nz_values.value, self.n_actions).T
+        return BlockDiagonalSparse(self.nz_values.value, self._n).T

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -22,20 +22,27 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
 
     $$
     S = \begin{bmatrix}
-        s_1 & 0 & \cdots & 0 & 0 \\
-        0 & s_2 & \cdots & 0 & 0 \\
-        \vdots & \vdots & \ddots & \vdots & \vdots \\
-        0 & 0 & \cdots & s_{\text{n_actions}} & 0 \\
-        0 & 0 & \cdots & 0 & 0
+        s_1    & 0      & \cdots & 0                        & 0 \\
+        0      & s_2    & \cdots & 0                        & 0 \\
+        \vdots & \vdots & \ddots & \vdots                   & \vdots \\
+        0      & 0      & \cdots & s_{\text{n_actions}}     & 0 \\
+        0      & 0      & \cdots & 0                        & 0
     \end{bmatrix}.
     $$
-    This effectively ignores the last ``n % n_actions`` rows of data.
+    
+    The non-zero values are stacked and stored as a single trainable parameter
+    ``nz_values`` with structure:
 
-    These are stacked and stored as a single trainable parameter ``nz_values``.
+    $$
+    \text{nz_values} = \begin{bmatrix}
+        s_1 & s_2 & \cdots s_{\text{n_actions}}
+    \end{bmatrix}^\mathrm{T}.
+    $$
 
     !!! note
-        The last block is included if necessary to pad the first dimension of the matrix
-        to be equal to ``n``. This effectively ignores the last ``n % n_actions`` rows of data.
+        The bottom right block of $S$ is implicitly included if necessary to pad its
+        first dimension to be equal to ``n``. It is never stored. This effectively
+        ignores the last ``n % n_actions`` rows of data.
     """
 
     def __init__(

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -72,6 +72,27 @@ class TestCongruenceTransform:
             C.to_dense(), congruence_transform(A.to_dense(), B.to_dense())
         )
 
+    @pytest.mark.parametrize("n, n_blocks", [(7, 3), (10, 2)])
+    def test_congruence_block_diagonal_sparse_scalar(
+        self, n, n_blocks, dtype=jnp.float64, key=jax.random.key(42)
+    ):
+        """Test overload where ``A`` is ``BlockDiagonalSparse`` and ``B`` is ``ScalarMul``."""
+        from cola.ops import ScalarMul
+
+        key, subkey = jax.random.split(key)
+        A = BlockDiagonalSparse(
+            jax.random.normal(subkey, (n,), dtype=dtype), n_blocks=n_blocks
+        )
+        scalar_val = 2.5
+        B = ScalarMul(scalar_val, (n, n), dtype=dtype)
+        C = congruence_transform(A, B)
+        assert isinstance(C, Diagonal)
+        assert C.shape == (n_blocks, n_blocks)
+        assert C.dtype == dtype
+        assert jnp.allclose(
+            C.to_dense(), congruence_transform(A.to_dense(), B.to_dense())
+        )
+
 
 class TestLowerCholesky:
     """Tests for ``lower_cholesky``."""

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -60,9 +60,9 @@ class TestCongruenceTransform:
     ):
         """Test overload where ``A`` is ``BlockDiagonalSparse`` and ``B`` is ``Diagonal``."""
         key, subkey = jax.random.split(key)
-        A = BlockDiagonalSparse(
-            jax.random.normal(subkey, (n,), dtype=dtype), n_blocks=n_blocks
-        )
+        block_size = n // n_blocks
+        nz_values = jax.random.normal(subkey, (n_blocks, block_size), dtype=dtype)
+        A = BlockDiagonalSparse(nz_values, n)
         B = Diagonal(jax.random.normal(subkey, (n,), dtype=dtype))
         C = congruence_transform(A, B)
         assert isinstance(C, Diagonal)
@@ -80,9 +80,9 @@ class TestCongruenceTransform:
         from cola.ops import ScalarMul
 
         key, subkey = jax.random.split(key)
-        A = BlockDiagonalSparse(
-            jax.random.normal(subkey, (n,), dtype=dtype), n_blocks=n_blocks
-        )
+        block_size = n // n_blocks
+        nz_values = jax.random.normal(subkey, (n_blocks, block_size), dtype=dtype)
+        A = BlockDiagonalSparse(nz_values, n)
         scalar_val = 2.5
         B = ScalarMul(scalar_val, (n, n), dtype=dtype)
         C = congruence_transform(A, B)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -498,8 +498,10 @@ class TestOrthogonalize:
         elif op_type is Identity:
             op = Identity((n, n // 2), dtype=dtype)
         elif op_type is BlockDiagonalSparse:
+            n_blocks = 3
+            n_nz_values = n // n_blocks
             op = BlockDiagonalSparse(
-                jax.random.normal(key, (n,), dtype=dtype), n_blocks=3
+                jax.random.normal(key, (n_nz_values, n_blocks), dtype=dtype), n
             )
         else:
             raise ValueError(f"Unknown operator type: {op_type}")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -43,7 +43,7 @@ class TestComputationAwareGP:
         if policy_class is LanczosPolicy:
             return policy_class(n_actions=n_actions, key=key)
         elif policy_class is BlockSparsePolicy:
-            return policy_class(n_actions=n_actions, n=n_train, key=key, dtype=dtype)
+            return policy_class(n_train, n_actions=n_actions, key=key, dtype=dtype)
         else:
             raise ValueError(f"Invalid policy class: {policy_class}")
 
@@ -210,19 +210,20 @@ class TestComputationAwareGP:
         assert jnp.allclose(kl, kl_explicit, rtol=1e-4)
 
     def test_prior_kl_gradient_sparse_actions(
-        self, posterior, n_train, train_data, dtype, key=jax.random.key(42)
+        self, posterior, n_train, train_data, dtype, n_actions, key=jax.random.key(42)
     ):
         """Test that ``prior_kl`` gradient wrt sparse action parameters is correct."""
         if dtype == jnp.float32:
             pytest.skip("Skipping float32 test due to numerical precision limitations")
 
         def kl_objective(nz_values):
-            policy = BlockSparsePolicy(n_actions=n_train, nz_values=nz_values)
+            policy = BlockSparsePolicy(n_train, nz_values=nz_values)
             cagp = ComputationAwareGP(posterior=posterior, policy=policy)
             cagp.condition(train_data)
             return cagp.prior_kl()
 
-        nz_values = jax.random.normal(key, (n_train,), dtype=dtype)
+        block_size = n_train // n_actions
+        nz_values = jax.random.normal(key, (n_actions, block_size), dtype=dtype)
         jax.test_util.check_grads(kl_objective, (nz_values,), order=1)
 
     def test_integration_elbo(self, conditioned_cagp, posterior, train_data, dtype):

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -58,22 +58,25 @@ class TestBlockDiagonalSparse:
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     def test_basic(self, shape, dtype, key=jax.random.key(42)):
         """Test initialization and basic properties."""
-        n_blocks, n_nz_values = shape
-        nz_values = jax.random.normal(key, (n_nz_values,), dtype=dtype)
-        op = BlockDiagonalSparse(nz_values, n_blocks)
+        n_blocks, n = shape
+        block_size = n // n_blocks
+        n_used = n_blocks * block_size
+        nz_values = jax.random.normal(key, (n_blocks, block_size), dtype=dtype)
+        op = BlockDiagonalSparse(nz_values, n)
         assert op.shape == shape
         assert op.dtype == dtype
         _test_linear_operator_consistency(op)
 
     def test_grad(self, shape, dtype=jnp.float64, key=jax.random.key(42)):
         """Test gradient containing the linear operator."""
-        n_blocks, n_nz_values = shape
+        n_blocks, n = shape
+        block_size = n // n_blocks
         key, subkey = jax.random.split(key)
-        nz_values = jax.random.normal(subkey, (n_nz_values,), dtype=dtype)
-        op = BlockDiagonalSparse(nz_values, n_blocks)
+        nz_values = jax.random.normal(subkey, (n_blocks, block_size), dtype=dtype)
+        op = BlockDiagonalSparse(nz_values, n)
 
         f = lambda x: jnp.prod(jnp.sin(op @ x))
-        x = jax.random.normal(key, (n_nz_values,), dtype=dtype)
+        x = jax.random.normal(key, (n,), dtype=dtype)
         jax.test_util.check_grads(f, (x,), order=1)
 
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -76,9 +76,13 @@ class TestBlockDiagonalSparse:
         nz_values = jax.random.normal(subkey, (n_blocks, block_size), dtype=dtype)
         op = BlockDiagonalSparse(nz_values, n)
 
-        f = lambda x: jnp.prod(jnp.sin(op @ x))
-        x = jax.random.normal(key, (n,), dtype=dtype)
-        jax.test_util.check_grads(f, (x,), order=1)
+        f1 = lambda x: jnp.prod(jnp.sin(op @ x))
+        x1 = jax.random.normal(key, (n_blocks,), dtype=dtype)
+        jax.test_util.check_grads(f1, (x1,), order=1)
+
+        f2 = lambda x: jnp.prod(jnp.sin(op.T @ x))
+        x2 = jax.random.normal(key, (n,), dtype=dtype)
+        jax.test_util.check_grads(f2, (x2,), order=1)
 
 
 class TestDiagLike:

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -103,11 +103,12 @@ class TestBlockSparsePolicy:
     @pytest.mark.parametrize("n", [10, 20])
     def test_init_basic(self, n_actions, n, key, dtype):
         """Test basic initialization."""
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy(n, n_actions=n_actions, key=key, dtype=dtype)
 
         assert policy.n_actions == n_actions
         assert isinstance(policy.nz_values, Real)
-        assert policy.nz_values.value.shape == (n,)
+        block_size = n // n_actions
+        assert policy.nz_values.value.shape == (n_actions, block_size)
         assert policy.nz_values.value.dtype == dtype
 
     @pytest.mark.parametrize("n_actions", [2, 3])
@@ -117,17 +118,16 @@ class TestBlockSparsePolicy:
         self, n_actions, n, dtype, key=jax.random.key(42)
     ):
         """Test initialization with provided nz_values."""
-        nz_values = jax.random.normal(key, (n,), dtype=dtype)
+        block_size = n // n_actions
+        nz_values = jax.random.normal(key, (n_actions, block_size), dtype=dtype)
 
-        policy = BlockSparsePolicy(n_actions=n_actions, nz_values=nz_values)
+        policy = BlockSparsePolicy(n, nz_values=nz_values)
         assert policy.n_actions == n_actions
         assert isinstance(policy.nz_values, Real)
         assert policy.nz_values.value.dtype == dtype
         assert jnp.allclose(policy.nz_values.value, nz_values)
 
-        policy_static = BlockSparsePolicy(
-            n_actions=n_actions, nz_values=Static(nz_values)
-        )
+        policy_static = BlockSparsePolicy(n, nz_values=Static(nz_values))
         assert isinstance(policy_static.nz_values, Static)
         assert policy_static.nz_values.value.dtype == dtype
         assert jnp.allclose(policy_static.nz_values.value, nz_values)
@@ -139,7 +139,7 @@ class TestBlockSparsePolicy:
         """Test to_actions consistency and return type."""
         n = psd_linear_operator.shape[0]
         dtype = psd_linear_operator.dtype
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy(n, n_actions=n_actions, key=key, dtype=dtype)
         _test_batch_policy_actions_consistency(policy, psd_linear_operator)
         action = policy.to_actions(psd_linear_operator)
         assert isinstance(action, Transpose)
@@ -152,7 +152,7 @@ class TestBlockSparsePolicy:
         """Test that to_actions produces reproducible results with same values."""
         n = psd_linear_operator.shape[0]
         dtype = psd_linear_operator.dtype
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy(n, n_actions=n_actions, key=key, dtype=dtype)
         actions1 = policy.to_actions(psd_linear_operator)
         actions2 = policy.to_actions(psd_linear_operator)
         assert jnp.allclose(actions1.to_dense(), actions2.to_dense())


### PR DESCRIPTION
This PR refactors `BlockDiagonalSparse` and downstream code to ensure blocks have uniform size, which results in discarding data if the number of actions doesn't divide evenly into the number of data points.