### PR TITLE
Add linear solvers Cholesky and PseudoInverse

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ plugins:
             show_root_toc_entry: true
             heading_level: 1
           inventories:
+            - https://docs.jax.dev/en/latest/objects.inv
             - https://docs.jaxgaussianprocesses.com/objects.inv
             - https://cola.readthedocs.io/en/stable/objects.inv
 

--- a/src/cagpjax/linalg/__init__.py
+++ b/src/cagpjax/linalg/__init__.py
@@ -1,6 +1,7 @@
 """Linear algebra functions."""
 
 from .congruence import congruence_transform
+from .eigh import eigh
 from .lower_cholesky import lower_cholesky
 
-__all__ = ["congruence_transform", "lower_cholesky"]
+__all__ = ["congruence_transform", "lower_cholesky", "eigh"]

--- a/src/cagpjax/linalg/eigh.py
+++ b/src/cagpjax/linalg/eigh.py
@@ -1,0 +1,53 @@
+"""Hermitian eigenvalue decomposition."""
+
+from typing import Any
+
+import cola
+from cola.ops import Diagonal, I_like, Identity, LinearOperator, ScalarMul
+from jaxtyping import Array, Float
+from typing_extensions import NamedTuple, overload
+
+
+class EighResult(NamedTuple):
+    """Result of Hermitian eigenvalue decomposition.
+
+    Attributes:
+        eigenvalues: Eigenvalues of the operator.
+        eigenvectors: Eigenvectors of the operator.
+    """
+
+    eigenvalues: Float[Array, "N"]
+    eigenvectors: LinearOperator
+
+
+def eigh(
+    A: LinearOperator, alg: cola.linalg.Algorithm = cola.linalg.Auto()
+) -> EighResult:
+    """Compute the Hermitian eigenvalue decomposition of a linear operator.
+
+    Args:
+        A: Hermitian linear operator.
+        alg: Algorithm for eigenvalue decomposition (see [`cola.linalg.eig`][]).
+
+    Returns:
+        A named tuple of `(eigenvalues, eigenvectors)` where `eigenvectors` is a unitary
+            `LinearOperator`.
+    """
+    vals, vecs = _eigh(A, alg)
+    return EighResult(vals, cola.Unitary(vecs))
+
+
+@overload
+def _eigh(A: LinearOperator, alg: cola.linalg.Algorithm):  # pyright: ignore[reportOverlappingOverload]
+    A = cola.SelfAdjoint(A)
+    return cola.linalg.eig(A, A.shape[0], which="LM", alg=alg)
+
+
+@overload
+def _eigh(A: ScalarMul | Diagonal | Identity, alg: cola.linalg.Algorithm):  # pyright: ignore[reportOverlappingOverload]
+    return cola.linalg.diag(A), I_like(A)
+
+
+@cola.dispatch
+def _eigh(A: Any, alg: cola.linalg.Algorithm):
+    pass

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass
 
 import cola
-import cola.linalg
 import jax.numpy as jnp
 from cola.ops import LinearOperator
 from gpjax.distributions import GaussianDistribution
@@ -12,9 +11,10 @@ from gpjax.mean_functions import Constant
 from jaxtyping import Array, Float
 from typing_extensions import override
 
-from ..linalg import congruence_transform, lower_cholesky
+from ..linalg import congruence_transform
 from ..operators import diag_like
 from ..policies import AbstractBatchLinearSolverPolicy
+from ..solvers import AbstractLinearSolver, AbstractLinearSolverMethod, Cholesky
 from ..typing import ScalarFloat
 from .base import AbstractComputationAwareGP
 
@@ -29,17 +29,22 @@ class ComputationAwareGP(AbstractComputationAwareGP):
     Attributes:
         posterior: The original (exact) posterior.
         policy: The batch linear solver policy.
-        jitter: Numerical jitter for stability.
+        solver_method: The linear solver method to use for solving linear systems
+            with positive semi-definite operators.
 
     Notes:
         - Only single-output models are currently supported.
     """
 
+    posterior: ConjugatePosterior
+    policy: AbstractBatchLinearSolverPolicy
+    solver_method: AbstractLinearSolverMethod
+
     def __init__(
         self,
         posterior: ConjugatePosterior,
         policy: AbstractBatchLinearSolverPolicy,
-        jitter: ScalarFloat = 1e-6,
+        solver_method: AbstractLinearSolverMethod = Cholesky(1e-6),
     ):
         """Initialize the Computation-Aware GP model.
 
@@ -47,12 +52,12 @@ class ComputationAwareGP(AbstractComputationAwareGP):
             posterior: GPJax conjugate posterior.
             policy: The batch linear solver policy that defines the subspace into
                 which the data is projected.
-            jitter: A small positive constant added to the diagonal of a covariance
-                matrix when necessary to ensure numerical stability.
+            solver_method: The linear solver method to use for solving linear systems with
+                positive semi-definite operators.
         """
         super().__init__(posterior)
-        self.policy: AbstractBatchLinearSolverPolicy = policy
-        self.jitter: ScalarFloat = jitter
+        self.policy = policy
+        self.solver_method = solver_method
         self._posterior_params: _ProjectedPosteriorParameters | None = None
 
     @property
@@ -91,19 +96,16 @@ class ComputationAwareGP(AbstractComputationAwareGP):
         proj = self.policy.to_actions(cov_prior).T
         obs_cov_proj = congruence_transform(proj, obs_cov)
         cov_prior_proj = congruence_transform(proj, cov_prior)
-        cov_prior_lchol_proj = lower_cholesky(cov_prior_proj, jitter=self.jitter)
+        cov_prior_proj_solver = self.solver_method(cov_prior_proj)
 
         residual_proj = proj @ (y - mean_prior)
-        inv_cov_prior_lchol_proj = cola.linalg.inv(cov_prior_lchol_proj)
-        repr_weights_proj = inv_cov_prior_lchol_proj.T @ (
-            inv_cov_prior_lchol_proj @ residual_proj
-        )
+        repr_weights_proj = cov_prior_proj_solver.solve(residual_proj)
 
         self._posterior_params = _ProjectedPosteriorParameters(
             x=x,
             proj=proj,
             obs_cov_proj=obs_cov_proj,
-            cov_prior_lchol_proj=cov_prior_lchol_proj,
+            cov_prior_proj_solver=cov_prior_proj_solver,
             residual_proj=residual_proj,
             repr_weights_proj=repr_weights_proj,
         )
@@ -133,7 +135,7 @@ class ComputationAwareGP(AbstractComputationAwareGP):
         # Unpack posterior parameters
         x = self._posterior_params.x
         proj = self._posterior_params.proj
-        cov_prior_lchol_proj = self._posterior_params.cov_prior_lchol_proj
+        cov_prior_proj_solver = self._posterior_params.cov_prior_proj_solver
         repr_weights_proj = self._posterior_params.repr_weights_proj
 
         # Predictions at test points
@@ -144,14 +146,13 @@ class ComputationAwareGP(AbstractComputationAwareGP):
         if isinstance(prior.mean_function, Constant):
             mean_z = mean_z.astype(prior.mean_function.constant.value.dtype)
         cov_zz = prior.kernel.gram(z)
-        cov_xz = cov_zz if test_inputs is None else prior.kernel.cross_covariance(x, z)
-        cov_xz_proj = proj @ cov_xz
+        cov_zx = cov_zz if test_inputs is None else prior.kernel.cross_covariance(z, x)
+        cov_zx_proj = cov_zx @ proj.T
 
         # Posterior predictive distribution
-        mean_pred = jnp.atleast_1d(mean_z + cov_xz_proj.T @ repr_weights_proj)
-        right_shift_factor = cola.linalg.inv(cov_prior_lchol_proj) @ cov_xz_proj
-        cov_pred = cov_zz - right_shift_factor.T @ right_shift_factor
-        cov_pred = cola.PSD(cov_pred + diag_like(cov_pred, self.jitter))
+        mean_pred = jnp.atleast_1d(mean_z + cov_zx_proj @ repr_weights_proj)
+        cov_pred = cov_zz - cov_prior_proj_solver.inv_congruence_transform(cov_zx_proj)
+        cov_pred = cola.PSD(cov_pred + diag_like(cov_pred, self.posterior.jitter))
 
         return GaussianDistribution(mean_pred, cov_pred)
 
@@ -174,18 +175,18 @@ class ComputationAwareGP(AbstractComputationAwareGP):
 
         # Unpack posterior parameters
         obs_cov_proj = self._posterior_params.obs_cov_proj
-        cov_prior_lchol_proj = self._posterior_params.cov_prior_lchol_proj
+        cov_prior_proj_solver = self._posterior_params.cov_prior_proj_solver
         residual_proj = self._posterior_params.residual_proj
         repr_weights_proj = self._posterior_params.repr_weights_proj
 
-        obs_cov_lchol_proj = lower_cholesky(obs_cov_proj, jitter=self.jitter)
+        obs_cov_proj_solver = self.solver_method(obs_cov_proj)
 
         kl = (
-            _kl_divergence_from_cholesky(
+            _kl_divergence_from_solvers(
                 residual_proj,
-                obs_cov_lchol_proj,
+                obs_cov_proj_solver,
                 jnp.zeros_like(residual_proj),
-                cov_prior_lchol_proj,
+                cov_prior_proj_solver,
             )
             - 0.5 * congruence_transform(repr_weights_proj.T, obs_cov_proj).squeeze()
         )
@@ -204,7 +205,7 @@ class _ProjectedPosteriorParameters:
         proj: Projection operator mapping from N-dimensional space
             to M-dimensional subspace.
         obs_cov_proj: Projected covariance of likelihood.
-        cov_prior_lchol_proj: Lower Cholesky factor of ``cov_prior_proj``.
+        cov_prior_proj_solver: Linear solver for ``cov_prior_proj``.
         residual_proj: Projected residuals between observations and prior mean.
         repr_weights_proj: Projected representer weights.
     """
@@ -212,28 +213,27 @@ class _ProjectedPosteriorParameters:
     x: Float[Array, "N D"]
     proj: LinearOperator
     obs_cov_proj: LinearOperator
-    cov_prior_lchol_proj: LinearOperator
+    cov_prior_proj_solver: AbstractLinearSolver
     residual_proj: Float[Array, "M"]
     repr_weights_proj: Float[Array, "M"]
 
 
-def _kl_divergence_from_cholesky(
+def _kl_divergence_from_solvers(
     mean_q: Float[Array, "N"],
-    lchol_cov_q: LinearOperator,
+    cov_q_solver: AbstractLinearSolver,
     mean_p: Float[Array, "N"],
-    lchol_cov_p: LinearOperator,
+    cov_p_solver: AbstractLinearSolver,
 ) -> ScalarFloat:
     """Compute KL divergence between two Gaussian distributions."""
     n = mean_q.shape[0]
     diff = mean_p - mean_q
 
     # tr(inv(cov_p) cov_q)
-    inner = jnp.sum(jnp.square(cola.solve(lchol_cov_p, lchol_cov_q.to_dense())))
+    inner = cov_p_solver.trace_solve(cov_q_solver)
 
     # (mean_p - mean_q)' inv(cov_p) (mean_p - mean_q)
-    mahalanobis = jnp.sum(jnp.square(cola.solve(lchol_cov_p, diff)))
+    mahalanobis = cov_p_solver.inv_quad(diff)
 
-    # log(det(cov_p) / det(cov_q)) / 2
-    logdet_ratio = cola.logdet(lchol_cov_p) - cola.logdet(lchol_cov_q)
+    logdet_ratio = cov_p_solver.logdet() - cov_q_solver.logdet()
 
-    return 0.5 * (inner + mahalanobis - n) + logdet_ratio
+    return 0.5 * (inner + logdet_ratio + mahalanobis - n)

--- a/src/cagpjax/solvers/__init__.py
+++ b/src/cagpjax/solvers/__init__.py
@@ -1,0 +1,6 @@
+from .base import AbstractLinearSolver, AbstractLinearSolverMethod
+
+__all__ = [
+    "AbstractLinearSolver",
+    "AbstractLinearSolverMethod",
+]

--- a/src/cagpjax/solvers/__init__.py
+++ b/src/cagpjax/solvers/__init__.py
@@ -1,8 +1,10 @@
 from .base import AbstractLinearSolver, AbstractLinearSolverMethod
 from .cholesky import Cholesky
+from .pseudoinverse import PseudoInverse
 
 __all__ = [
     "AbstractLinearSolver",
     "AbstractLinearSolverMethod",
     "Cholesky",
+    "PseudoInverse",
 ]

--- a/src/cagpjax/solvers/__init__.py
+++ b/src/cagpjax/solvers/__init__.py
@@ -1,6 +1,8 @@
 from .base import AbstractLinearSolver, AbstractLinearSolverMethod
+from .cholesky import Cholesky
 
 __all__ = [
     "AbstractLinearSolver",
     "AbstractLinearSolverMethod",
+    "Cholesky",
 ]

--- a/src/cagpjax/solvers/base.py
+++ b/src/cagpjax/solvers/base.py
@@ -23,7 +23,7 @@ class AbstractLinearSolver(nnx.Module):
 
     @abstractmethod
     def solve(self, b: Float[Array, "N #K"]) -> Float[Array, "N #K"]:
-        """Computat a solution to the linear system $Ax = b$.
+        """Compute a solution to the linear system $Ax = b$.
 
         Arguments:
             b: Right-hand side of the linear system.
@@ -36,13 +36,26 @@ class AbstractLinearSolver(nnx.Module):
         pass
 
     @abstractmethod
+    def inv_congruence_transform(
+        self, B: LinearOperator | Float[Array, "K N"]
+    ) -> LinearOperator | Float[Array, "K K"]:
+        """Compute the inverse congruence transform $B x$ for $x$ in $Ax = B^T$.
+
+        Arguments:
+            B: Linear operator or array to be applied.
+
+        Returns:
+            Linear operator or array resulting from the congruence transform.
+        """
+        pass
+
     def inv_quad(self, b: Float[Array, "N #1"]) -> ScalarFloat:
         """Compute the inverse quadratic form $b^T x$, for $x$ in $Ax = b$.
 
         Arguments:
             b: Right-hand side of the linear system.
         """
-        pass
+        return self.inv_congruence_transform(b.reshape(1, -1)).squeeze()
 
     @abstractmethod
     def trace_solve(self, B: Self) -> ScalarFloat:

--- a/src/cagpjax/solvers/base.py
+++ b/src/cagpjax/solvers/base.py
@@ -1,0 +1,68 @@
+"""Base classes for linear solvers and methods."""
+
+from abc import abstractmethod
+
+from cola.ops import LinearOperator
+from flax import nnx
+from jaxtyping import Array, Float
+from typing_extensions import Self
+
+from ..typing import ScalarFloat
+
+
+class AbstractLinearSolver(nnx.Module):
+    """
+    Base class for linear solvers.
+
+    These solvers are used to exactly or approximately solve the linear
+    system $Ax = b$ for $x$, where $A$ is a positive (semi-)definite (PSD)
+    linear operator.
+
+    Solvers should always be constructed by a `AbstractLinearSolverMethod`.
+    """
+
+    @abstractmethod
+    def solve(self, b: Float[Array, "N #K"]) -> Float[Array, "N #K"]:
+        """Computat a solution to the linear system $Ax = b$.
+
+        Arguments:
+            b: Right-hand side of the linear system.
+        """
+        pass
+
+    @abstractmethod
+    def logdet(self) -> ScalarFloat:
+        """Compute the logarithm of the (pseudo-)determinant of $A$."""
+        pass
+
+    @abstractmethod
+    def inv_quad(self, b: Float[Array, "N #1"]) -> ScalarFloat:
+        """Compute the inverse quadratic form $b^T x$, for $x$ in $Ax = b$.
+
+        Arguments:
+            b: Right-hand side of the linear system.
+        """
+        pass
+
+    @abstractmethod
+    def trace_solve(self, B: Self) -> ScalarFloat:
+        r"""Compute $\mathrm{trace}(X)$ in $AX=B$ for PSD $B$.
+
+        Arguments:
+            B: An `AbstractLinearSolver` of the same type as `self` representing
+                the PSD linear operator $B$.
+        """
+        pass
+
+
+class AbstractLinearSolverMethod(nnx.Module):
+    """
+    Base class for linear solver methods.
+
+    These methods are used to construct `AbstractLinearSolver` instances.
+    """
+
+    @abstractmethod
+    def __call__(self, A: LinearOperator) -> AbstractLinearSolver:
+        """Construct a solver from the positive (semi-)definite linear operator."""
+        pass

--- a/src/cagpjax/solvers/cholesky.py
+++ b/src/cagpjax/solvers/cholesky.py
@@ -1,0 +1,65 @@
+"""Linear solvers based on Cholesky decomposition."""
+
+import cola
+import jax.numpy as jnp
+from cola.ops import LinearOperator
+from jaxtyping import Array, Float
+from typing_extensions import Self, override
+
+from ..linalg import lower_cholesky
+from ..typing import ScalarFloat
+from .base import AbstractLinearSolver, AbstractLinearSolverMethod
+
+
+class Cholesky(AbstractLinearSolverMethod):
+    """
+    Solve a linear system using the Cholesky decomposition.
+
+    Due to numerical imprecision, Cholesky factorization may fail even for
+    positive-definite $A$. Optionally, a small amount of `jitter` ($\\epsilon$) can
+    be added to $A$ to ensure positive-definiteness. Note that the resulting system
+    solved is slightly different from the original system.
+
+    Attributes:
+        jitter: Small amount of jitter to add to $A$ to ensure positive-definiteness.
+    """
+
+    jitter: ScalarFloat | None
+
+    def __init__(self, jitter: ScalarFloat | None = None):
+        self.jitter = jitter
+
+    @override
+    def __call__(self, A: LinearOperator) -> AbstractLinearSolver:
+        return CholeskySolver(A, jitter=self.jitter)
+
+
+class CholeskySolver(AbstractLinearSolver):
+    """
+    Solve a linear system by computing the Cholesky decomposition.
+    """
+
+    lchol: LinearOperator
+
+    def __init__(self, A: LinearOperator, jitter: ScalarFloat | None = None):
+        self.lchol = lower_cholesky(A, jitter)
+
+    @override
+    def solve(self, b: Float[Array, "N #K"]) -> Float[Array, "N #K"]:
+        Linv = cola.linalg.inv(self.lchol)
+        return Linv.T @ (Linv @ b)
+
+    @override
+    def logdet(self) -> ScalarFloat:
+        return 2 * jnp.sum(jnp.log(cola.linalg.diag(self.lchol)))
+
+    @override
+    def inv_quad(self, b: Float[Array, "N #1"]) -> ScalarFloat:
+        Linv = cola.linalg.inv(self.lchol)
+        z = Linv @ b
+        return jnp.sum(jnp.square(z))
+
+    @override
+    def trace_solve(self, B: Self) -> ScalarFloat:
+        L = cola.linalg.inv(self.lchol) @ B.lchol.to_dense()
+        return jnp.sum(jnp.square(L))

--- a/src/cagpjax/solvers/cholesky.py
+++ b/src/cagpjax/solvers/cholesky.py
@@ -54,10 +54,12 @@ class CholeskySolver(AbstractLinearSolver):
         return 2 * jnp.sum(jnp.log(cola.linalg.diag(self.lchol)))
 
     @override
-    def inv_quad(self, b: Float[Array, "N #1"]) -> ScalarFloat:
+    def inv_congruence_transform(
+        self, B: LinearOperator | Float[Array, "N K"]
+    ) -> LinearOperator | Float[Array, "K K"]:
         Linv = cola.linalg.inv(self.lchol)
-        z = Linv @ b
-        return jnp.sum(jnp.square(z))
+        right_term = Linv @ B.T
+        return right_term.T @ right_term
 
     @override
     def trace_solve(self, B: Self) -> ScalarFloat:

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -1,0 +1,112 @@
+import cola
+import jax
+from cola.ops import LinearOperator
+from jax import numpy as jnp
+from jaxtyping import Array, Float
+from typing_extensions import Self, override
+
+from ..linalg.eigh import EighResult, eigh
+from ..typing import ScalarFloat
+from .base import AbstractLinearSolver, AbstractLinearSolverMethod
+
+
+class PseudoInverse(AbstractLinearSolverMethod):
+    """
+    Solve a linear system using the Moore-Penrose pseudoinverse.
+
+    This solver computes the least-squares solution $x = A^+ b$ for any $A$,
+    where $A^+$ is the Moore-Penrose pseudoinverse. This is equivalent to
+    the exact solution for non-singular $A$ but generalizes to singular $A$
+    and improves stability for almost-singular $A$; note, however, that if the
+    rank of $A$ is dependent on hyperparameters being optimized, because the
+    pseudoinverse is discontinuous, the optimization problem may be ill-posed.
+
+    Attributes:
+        alg: Algorithm for eigenvalue decomposition passed to [`eigh`][].
+        rtol: Specifies the cutoff for small eigenvalues.
+              Eigenvalues smaller than `rtol * largest_nonzero_eigenvalue` are treated as zero.
+              The default is determined based on the floating point precision of the dtype
+              of the operator (see [`jax.numpy.linalg.pinv`][]).
+    """
+
+    alg: cola.linalg.Algorithm
+    rtol: ScalarFloat | None
+
+    def __init__(
+        self,
+        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
+        rtol: ScalarFloat | None = None,
+    ):
+        self.alg = alg
+        self.rtol = rtol
+
+    @override
+    def __call__(self, A: LinearOperator) -> AbstractLinearSolver:
+        return PseudoInverseSolver(A, alg=self.alg, rtol=self.rtol)
+
+
+class PseudoInverseSolver(AbstractLinearSolver):
+    """
+    Solve a linear system using the Moore-Penrose pseudoinverse.
+    """
+
+    A: LinearOperator
+    eigh_result: EighResult
+    eigenvalues_safe: Float[Array, "N"]
+
+    def __init__(
+        self,
+        A: LinearOperator,
+        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
+        rtol: ScalarFloat | None = None,
+    ):
+        n = A.shape[0]
+        # select rtol using same heuristic as jax.numpy.linalg.lstsq
+        if rtol is None:
+            rtol = float(jnp.finfo(A.dtype).eps) * n
+        self.eigh_result = eigh(A, alg=alg)
+        svdmax = jnp.max(jnp.abs(self.eigh_result.eigenvalues))
+        cutoff = jnp.array(rtol * svdmax, dtype=svdmax.dtype)
+        mask = self.eigh_result.eigenvalues >= cutoff
+        self.eigvals_safe = jnp.where(mask, self.eigh_result.eigenvalues, 1)
+        self.eigvals_inv = jnp.where(mask, jnp.reciprocal(self.eigvals_safe), 0)
+        self.A = A
+
+    @override
+    def solve(self, b: Float[Array, "N #K"]) -> Float[Array, "N #K"]:
+        # return jnp.linalg.lstsq(self.A.to_dense(), b)[0]
+        b_ndim = b.ndim
+        b = b if b_ndim == 2 else b[:, None]
+        with jax.default_matmul_precision("highest"):
+            x = self.eigh_result.eigenvectors.T @ b
+        x = x * self.eigvals_inv[:, None]
+        with jax.default_matmul_precision("highest"):
+            x = self.eigh_result.eigenvectors @ x
+        x = x if b_ndim == 2 else x.squeeze(axis=1)
+        return x
+
+    @override
+    def logdet(self) -> ScalarFloat:
+        return jnp.sum(jnp.log(self.eigvals_safe))
+
+    @override
+    def inv_quad(self, b: Float[Array, "N #1"]) -> ScalarFloat:
+        z = self.eigh_result.eigenvectors.T @ b
+        return jnp.dot(jnp.square(z), self.eigvals_inv).squeeze()
+
+    @override
+    def trace_solve(self, B: Self) -> ScalarFloat:
+        if isinstance(B.eigh_result.eigenvectors, cola.ops.Dense):
+            vectors_mat = self.eigh_result.eigenvectors.to_dense()
+            return jnp.einsum(
+                "ij,j,kj,ik",
+                vectors_mat,
+                self.eigvals_inv,
+                vectors_mat,
+                B.A.to_dense(),
+            )
+        else:
+            W = B.eigh_result.eigenvectors.T @ self.eigh_result.eigenvectors.to_dense()
+            return jnp.einsum(
+                "ij,j,ij,i", W, self.eigvals_inv, W, B.eigh_result.eigenvalues
+            )

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -35,7 +35,7 @@ class PseudoInverse(AbstractLinearSolverMethod):
     def __init__(
         self,
         rtol: ScalarFloat | None = None,
-        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
+        alg: cola.linalg.Algorithm = cola.linalg.Eigh(),
     ):
         self.rtol = rtol
         self.alg = alg

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -22,11 +22,11 @@ class PseudoInverse(AbstractLinearSolverMethod):
     pseudoinverse is discontinuous, the optimization problem may be ill-posed.
 
     Attributes:
-        alg: Algorithm for eigenvalue decomposition passed to [`cagpjax.linalg.eigh`][].
         rtol: Specifies the cutoff for small eigenvalues.
               Eigenvalues smaller than `rtol * largest_nonzero_eigenvalue` are treated as zero.
               The default is determined based on the floating point precision of the dtype
               of the operator (see [`jax.numpy.linalg.pinv`][]).
+        alg: Algorithm for eigenvalue decomposition passed to [`cagpjax.linalg.eigh`][].
     """
 
     alg: cola.linalg.Algorithm
@@ -34,15 +34,15 @@ class PseudoInverse(AbstractLinearSolverMethod):
 
     def __init__(
         self,
-        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
         rtol: ScalarFloat | None = None,
+        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
     ):
-        self.alg = alg
         self.rtol = rtol
+        self.alg = alg
 
     @override
     def __call__(self, A: LinearOperator) -> AbstractLinearSolver:
-        return PseudoInverseSolver(A, alg=self.alg, rtol=self.rtol)
+        return PseudoInverseSolver(A, rtol=self.rtol, alg=self.alg)
 
 
 class PseudoInverseSolver(AbstractLinearSolver):
@@ -57,8 +57,8 @@ class PseudoInverseSolver(AbstractLinearSolver):
     def __init__(
         self,
         A: LinearOperator,
-        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
         rtol: ScalarFloat | None = None,
+        alg: cola.linalg.Algorithm = cola.linalg.Auto(),
     ):
         n = A.shape[0]
         # select rtol using same heuristic as jax.numpy.linalg.lstsq

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -6,7 +6,8 @@ import jax.numpy as jnp
 import pytest
 from cola.ops import Dense, Diagonal, I_like, LinearOperator, Triangular
 
-from cagpjax.linalg import congruence_transform, lower_cholesky
+from cagpjax.linalg import congruence_transform, eigh, lower_cholesky
+from cagpjax.linalg.eigh import EighResult
 from cagpjax.operators import BlockDiagonalSparse
 
 jax.config.update("jax_enable_x64", True)
@@ -71,6 +72,77 @@ class TestCongruenceTransform:
         assert jnp.allclose(
             C.to_dense(), congruence_transform(A.to_dense(), B.to_dense())
         )
+
+
+class TestEigh:
+    """Tests for ``eigh``."""
+
+    @pytest.fixture(params=[42, 78, 36])
+    def key(self, request):
+        return jax.random.key(request.param)
+
+    @pytest.fixture(params=[5, 10, 30])
+    def n(self, request):
+        return request.param
+
+    @pytest.fixture(params=[jnp.float32, jnp.float64])
+    def dtype(self, request):
+        return request.param
+
+    @pytest.fixture(
+        params=[
+            cola.ops.Dense,
+            cola.ops.Diagonal,
+            cola.ops.ScalarMul,
+            cola.ops.Identity,
+        ]
+    )
+    def op(self, request, n, dtype, key):
+        if request.param is Diagonal:
+            return Diagonal(jax.random.normal(key, (n,), dtype=dtype))
+        elif request.param is cola.ops.ScalarMul:
+            return cola.ops.ScalarMul(
+                jax.random.normal(key, dtype=dtype), (n, n), dtype=dtype
+            )
+        elif request.param is cola.ops.Identity:
+            return cola.ops.Identity((n, n), dtype=dtype)
+        else:
+            A = jax.random.normal(key, (n, n), dtype=dtype)
+            return cola.ops.Dense(A + A.T)
+
+    @pytest.fixture(params=[cola.linalg.Auto, cola.linalg.Eigh, cola.linalg.Lanczos])
+    def alg(self, request):
+        return request.param()
+
+    def test_eigh(self, op, n, dtype, alg):
+        """Test eigh for various operators."""
+        result = eigh(op, alg=alg)
+        assert isinstance(result, EighResult)
+        assert isinstance(result.eigenvalues, jnp.ndarray)
+        assert result.eigenvalues.shape == (n,)
+        assert result.eigenvalues.dtype == dtype
+        assert isinstance(result.eigenvectors, cola.ops.LinearOperator)
+        assert result.eigenvectors.isa(cola.Unitary)
+        assert result.eigenvectors.shape == (n, n)
+        assert result.eigenvectors.dtype == dtype
+        if isinstance(op, (cola.ops.Diagonal, cola.ops.ScalarMul, cola.ops.Identity)):
+            assert jnp.array_equal(result.eigenvalues, cola.linalg.diag(op))
+            assert isinstance(result.eigenvectors, cola.ops.Identity)
+        else:
+            with jax.default_matmul_precision("highest"):
+                op_mat = (
+                    result.eigenvectors
+                    @ jnp.diag(result.eigenvalues)
+                    @ result.eigenvectors.T
+                )
+            rtol = 1e-2 if dtype == jnp.float32 else 0.0
+            assert jnp.allclose(op_mat, op.to_dense(), rtol=rtol)
+            if isinstance(alg, (cola.linalg.Eigh, cola.linalg.Auto)):
+                result_jax = jax.numpy.linalg.eigh(op.to_dense())
+                assert jnp.allclose(result.eigenvalues, result_jax.eigenvalues)
+                assert jnp.allclose(
+                    result.eigenvectors.to_dense(), result_jax.eigenvectors
+                )
 
 
 class TestLowerCholesky:

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -157,13 +157,9 @@ class TestSolvers:
 
         assert cong_transform.shape == (m, m)
         assert cong_transform.dtype == dtype
-        if B_type == jnp.ndarray:
-            assert isinstance(cong_transform, jnp.ndarray)
-            assert jnp.allclose(cong_trans_mat, cong_trans_ref_mat)
-        else:
-            assert isinstance(cong_transform, cola.ops.LinearOperator)
-            rtol = 1e-4 if dtype == jnp.float32 else 1e-12
-            assert jnp.allclose(cong_trans_mat, cong_trans_ref_mat, rtol=rtol)
+        rtol = 1e-4 if dtype == jnp.float32 else 1e-12
+        assert isinstance(cong_transform, B_type)
+        assert jnp.allclose(cong_trans_mat, cong_trans_ref_mat, rtol=rtol)
 
     def test_inv_quad_consistency(self, solver, n, dtype, key=jax.random.key(23)):
         """Test inv_quad is consistent with solve."""

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,0 +1,156 @@
+"""Tests for the linear solvers."""
+
+import cola
+import jax
+import jax.numpy as jnp
+import pytest
+from jaxtyping import Array, Float
+
+from cagpjax.operators import diag_like
+from cagpjax.solvers import Cholesky, PseudoInverse
+from cagpjax.solvers.cholesky import CholeskySolver
+from cagpjax.solvers.pseudoinverse import PseudoInverseSolver
+
+jax.config.update("jax_enable_x64", True)
+
+
+class TestSolvers:
+    """
+    Test the solvers for the linear system of equations Ax = b.
+    """
+
+    @pytest.fixture(params=[4, 10])
+    def n(self, request) -> int:
+        """Size of the square operator A."""
+        return request.param
+
+    @pytest.fixture(params=[jnp.float32, jnp.float64])
+    def dtype(self, request):
+        """Data type of the operator A."""
+        return request.param
+
+    @pytest.fixture(params=["nonsingular", "singular", "almost_singular"])
+    def op_type(self, request) -> str:
+        """Type of the operator (how close to singular it is)."""
+        return request.param
+
+    def random_semiorthogonal(self, key, n, dtype) -> Float[Array, "N N"]:
+        """Generate a random semiorthogonal matrix."""
+        A = jax.random.normal(key, (n, n), dtype=dtype)
+        Q, _ = jnp.linalg.qr(A)
+        return Q
+
+    @pytest.fixture(params=[23, 98, 30])
+    def op(self, request, n, dtype, op_type) -> cola.ops.LinearOperator:
+        """Generate a random linear operator operator of the specified type."""
+        key = jax.random.key(request.param)
+        key, subkey = jax.random.split(key)
+        eigenvectors = self.random_semiorthogonal(subkey, n, dtype)
+
+        n_small = 0 if op_type == "nonsingular" else 2
+        eigenvalues = jax.random.uniform(key, (n - n_small,), dtype=dtype)
+        if op_type == "almost_singular":
+            eigmin = jnp.full(
+                n_small, jnp.finfo(dtype).eps * jnp.max(eigenvalues) / 10.0
+            )
+        else:
+            eigmin = jnp.zeros(n_small, dtype=dtype)
+        eigenvalues = jnp.concatenate([eigenvalues, eigmin])
+        A = eigenvectors.T @ jnp.diag(eigenvalues) @ eigenvectors
+        A = cola.lazify(A)
+        if op_type == "singular":
+            return cola.SelfAdjoint(A)
+        else:
+            return cola.PSD(A)
+
+    @pytest.fixture(params=[PseudoInverse, Cholesky])
+    def solver_method(self, request, op_type, dtype):
+        """Return a solver method for the linear system of equations op @ x = b."""
+        if request.param == PseudoInverse:
+            return PseudoInverse(rtol=0.0 if op_type == "nonsingular" else None)
+        elif request.param == Cholesky:
+            if dtype == jnp.float32:
+                pytest.skip("Cholesky is not very numerically stable for float32")
+            jitter = 0.0 if op_type == "nonsingular" else 1e-6
+            return Cholesky(jitter)
+
+    @pytest.fixture
+    def solver(self, solver_method, op):
+        """Return a solver for the linear system of equations op @ x = b."""
+        return solver_method(op)
+
+    @pytest.fixture(params=[cola.ops.Dense, cola.ops.Diagonal])
+    def other_op(
+        self, request, n, dtype, key=jax.random.key(78)
+    ) -> cola.ops.LinearOperator:
+        """Generate another PSD linear operator for the trace solve test."""
+        if request.param == cola.ops.Dense:
+            A = jax.random.normal(key, (n, n), dtype=dtype)
+            A = cola.lazify(A @ A.T)
+            return cola.PSD(A)
+        elif request.param == cola.ops.Diagonal:
+            return cola.PSD(
+                cola.ops.Diagonal(jax.random.normal(key, (n,), dtype=dtype) ** 2)
+            )
+
+    @pytest.fixture
+    def other_solver(self, solver_method, other_op):
+        """Return a solver for the linear system of equations other_op @ x = b."""
+        if isinstance(solver_method, Cholesky):
+            # Because the operator is PSD, we can set jitter to 0.0.
+            return Cholesky()(other_op)
+        return solver_method(other_op)
+
+    def test_solver_construction(self, solver_method, op):
+        """Test the construction of the solver."""
+        solver = solver_method(op)
+        if isinstance(solver_method, Cholesky):
+            assert isinstance(solver, CholeskySolver)
+            jitter = solver_method.jitter
+            op_actual = op if jitter is None else op + diag_like(op, jitter)
+            assert jnp.allclose(
+                (solver.lchol @ solver.lchol.T).to_dense(), op_actual.to_dense()
+            )
+        elif isinstance(solver_method, PseudoInverse):
+            assert isinstance(solver, PseudoInverseSolver)
+            assert solver.A is op
+
+    @pytest.mark.parametrize("tail_shape", [(), (2,)])
+    def test_solve(
+        self, tail_shape, solver_method, solver, op, n, dtype, key=jax.random.key(90)
+    ):
+        """Test the solve method of the solver."""
+        b = jax.random.normal(key, (n, *tail_shape), dtype=dtype)
+        x = solver.solve(b)
+        assert x.shape == b.shape
+        assert x.dtype == b.dtype
+
+        if isinstance(solver_method, Cholesky):
+            jitter = solver_method.jitter
+            op_actual = op if jitter is None else op + diag_like(op, jitter)
+        else:
+            op_actual = op
+
+        x_lstsq = jnp.linalg.lstsq(op_actual.to_dense(), b)[0]
+        # increased rtol for float32 because lstsq and eigh use different algorithms,
+        # and this makes more of a difference for float32
+        rtol = (1e-3 if dtype == jnp.float32 else 1e-8) * n
+        assert jnp.allclose(x, x_lstsq, rtol=rtol)
+
+    def test_inv_quad_consistency(self, solver, n, dtype, key=jax.random.key(23)):
+        """Test inv_quad is consistent with solve."""
+        b = jax.random.normal(key, (n,), dtype=dtype)
+
+        inv_quad = solver.inv_quad(b)
+        assert jnp.isscalar(inv_quad)
+        assert inv_quad.dtype == dtype
+        assert jnp.isclose(inv_quad, jnp.dot(b, solver.solve(b)))
+
+    def test_trace_solve_consistency(self, solver, other_solver, other_op, n, dtype):
+        """Test trace_solve is consistent with solve."""
+        trace_solve = solver.trace_solve(other_solver)
+        assert jnp.isscalar(trace_solve)
+        assert trace_solve.dtype == dtype
+        trace_solve_solve = jnp.trace(solver.solve(other_op.to_dense()))
+        rtol = (1e-4 if dtype == jnp.float32 else 1e-12) * n
+        assert jnp.isclose(trace_solve, trace_solve_solve, rtol=rtol)


### PR DESCRIPTION
This PR adds `AbstractLinearSolverMethod`s for specifying how solves ("inversion" of positive semi-definite operators) are performed.

The key design change is that instead of providing `jitter` to `ComputationAwareGP`, the user may provide one of the following solver methods:
- `Cholesky(jitter=1e-6)` (default): Uses a Cholesky solve with optional jitter
- `PseudoInverse(...)`: Uses the Moore-Penrose pseudoinverse

This provides a few more knobs to turn to improve stability when optimizing hyperparameters. Read on for more background.

**Background**

A few scenarios can result in a singular matrix `S.T @ (sigma**2 * I + Kxx) @ S` for actions matrix `S`:
1. We can have noiseless observations (`sigma == 0`) and rank-deficient `Kxx` (implying that the support of the GP prior is a subspace). This can happen when multiple observations are made at the same inputs (even if the observations are numerically equivalent).
2. `S` can be rank-deficient, resulting so that the effective number of actions is fewer than the user-specified number.
3. Neither of the above may be true, but simply due to numerical error, the matrix may be too close to singular to compute a Cholesky solve.

The current approach (termed "jitter" or "nugget"), which seems to be most popular in GP libraries including GPJax, adds a scalar matrix with a small diagonal to the PSD matrix to make it positive-definite so the Cholesky solve can be computed.

Alternatively, one can use the Moore-Penrose pseudoinverse (and pseudodeterminant in the KL divergence). This option is attractive for several reasons:
1. The GP posterior has the same support as the GP prior, while jitter may expand the support. When the restricted support is due to multiple observations at the same inputs, the result is the same as if the average of the outputs corresponding to a shared input was observed.
2. The CaGP approximation is the same as if we discarded all redundant actions in `S`.
3. It seems to also improve stability when the matrix becomes almost singular.

However, in local experiments, neither approach seems to be universally better than the other, so for now we keep the jitter approach the default for consistency with GPJax.

For further comparison of the two methods, see https://arxiv.org/abs/1602.00853