### PR TITLE
Make eigh more robust for degenerate operators

### DIFF
--- a/src/cagpjax/linalg/eigh.py
+++ b/src/cagpjax/linalg/eigh.py
@@ -3,9 +3,14 @@
 from typing import Any
 
 import cola
+import jax
 from cola.ops import Diagonal, I_like, Identity, LinearOperator, ScalarMul
-from jaxtyping import Array, Float
+from jax import numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import NamedTuple, overload
+
+from ..operators import diag_like
+from ..typing import ScalarFloat
 
 
 class EighResult(NamedTuple):
@@ -21,18 +26,35 @@ class EighResult(NamedTuple):
 
 
 def eigh(
-    A: LinearOperator, alg: cola.linalg.Algorithm = cola.linalg.Auto()
+    A: LinearOperator,
+    alg: cola.linalg.Algorithm = cola.linalg.Auto(),
+    jitter: ScalarFloat | Float[Array, "N"] | None = None,
+    key: PRNGKeyArray | None = None,
 ) -> EighResult:
     """Compute the Hermitian eigenvalue decomposition of a linear operator.
 
     Args:
         A: Hermitian linear operator.
         alg: Algorithm for eigenvalue decomposition (see [`cola.linalg.eig`][]).
+        jitter: Jitter to add to diagonal to stabilize gradients for
+            (almost-)degenerate matrices. If scalar, random jitter in `[0, jitter]`
+            is generated. If vector, it's added directly.
+        key: Random key for jitter generation. Defaults to `key(0)` if not provided.
 
     Returns:
         A named tuple of `(eigenvalues, eigenvectors)` where `eigenvectors` is a unitary
             `LinearOperator`.
     """
+    if jitter is not None:
+        if jnp.isscalar(jitter):
+            if key is None:
+                key = jax.random.key(0)
+            n = A.shape[0]
+            jitter_values = jax.random.uniform(key, (n,), dtype=A.dtype, maxval=jitter)
+        else:
+            jitter_values = jnp.asarray(jitter, dtype=A.dtype)
+        A = _add_jitter(A, jitter_values)
+
     vals, vecs = _eigh(A, alg)
     return EighResult(vals, cola.Unitary(vecs))
 
@@ -50,4 +72,22 @@ def _eigh(A: ScalarMul | Diagonal | Identity, alg: cola.linalg.Algorithm):  # py
 
 @cola.dispatch
 def _eigh(A: Any, alg: cola.linalg.Algorithm):
+    pass
+
+
+# fallback implementation
+@overload
+def _add_jitter(A: LinearOperator, jitter: Float[Array, "N"]) -> LinearOperator:
+    return A + diag_like(A, jitter)
+
+
+@overload
+def _add_jitter(  # pyright: ignore[reportOverlappingOverload]
+    A: ScalarMul | Diagonal | Identity, jitter: Float[Array, "N"]
+) -> Diagonal:
+    return Diagonal(cola.linalg.diag(A) + jitter)
+
+
+@cola.dispatch
+def _add_jitter(A: Any, jitter: Any) -> Any:
     pass

--- a/src/cagpjax/linalg/eigh.py
+++ b/src/cagpjax/linalg/eigh.py
@@ -9,8 +9,8 @@ from jax import numpy as jnp
 from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import NamedTuple, overload
 
-from ..operators import diag_like
 from ..typing import ScalarFloat
+from .utils import _add_jitter
 
 
 class EighResult(NamedTuple):
@@ -72,22 +72,4 @@ def _eigh(A: ScalarMul | Diagonal | Identity, alg: cola.linalg.Algorithm):  # py
 
 @cola.dispatch
 def _eigh(A: Any, alg: cola.linalg.Algorithm):
-    pass
-
-
-# fallback implementation
-@overload
-def _add_jitter(A: LinearOperator, jitter: Float[Array, "N"]) -> LinearOperator:
-    return A + diag_like(A, jitter)
-
-
-@overload
-def _add_jitter(  # pyright: ignore[reportOverlappingOverload]
-    A: ScalarMul | Diagonal | Identity, jitter: Float[Array, "N"]
-) -> Diagonal:
-    return Diagonal(cola.linalg.diag(A) + jitter)
-
-
-@cola.dispatch
-def _add_jitter(A: Any, jitter: Any) -> Any:
     pass

--- a/src/cagpjax/linalg/lower_cholesky.py
+++ b/src/cagpjax/linalg/lower_cholesky.py
@@ -1,14 +1,11 @@
 """Lower Cholesky decomposition of positive semidefinite operators."""
 
-from typing import Any
-
 import cola
 import gpjax.lower_cholesky
-from cola.ops import Diagonal, LinearOperator
-from typing_extensions import overload
+from cola.ops import LinearOperator
 
-from ..operators import diag_like
 from ..typing import ScalarFloat
+from .utils import _add_jitter
 
 
 def lower_cholesky(
@@ -31,19 +28,3 @@ def lower_cholesky(
 def _lower_cholesky_jittered(A: LinearOperator, jitter: ScalarFloat) -> LinearOperator:
     A_jittered = _add_jitter(A, jitter)
     return gpjax.lower_cholesky.lower_cholesky(cola.PSD(A_jittered))
-
-
-# fallback implementation
-@overload
-def _add_jitter(A: LinearOperator, jitter: ScalarFloat) -> LinearOperator:
-    return A + diag_like(A, jitter)
-
-
-@overload
-def _add_jitter(A: Diagonal, jitter: ScalarFloat) -> Diagonal:  # pyright: ignore[reportOverlappingOverload]
-    return Diagonal(A.diag + jitter)
-
-
-@cola.dispatch
-def _add_jitter(A: Any, jitter: ScalarFloat) -> Any:
-    pass

--- a/src/cagpjax/linalg/utils.py
+++ b/src/cagpjax/linalg/utils.py
@@ -1,0 +1,41 @@
+"""Linear algebra utilities."""
+
+from typing import Any
+
+import cola
+from cola.ops import Diagonal, Identity, LinearOperator, ScalarMul
+from jaxtyping import Array, Float
+from typing_extensions import overload
+
+from ..operators import diag_like
+from ..typing import ScalarFloat
+
+
+# fallback implementation
+@overload
+def _add_jitter(
+    A: LinearOperator, jitter: ScalarFloat | Float[Array, "N"]
+) -> LinearOperator:
+    return A + diag_like(A, jitter)
+
+
+@overload
+def _add_jitter(A: ScalarMul, jitter: ScalarFloat) -> ScalarMul:  # pyright: ignore[reportOverlappingOverload]
+    return ScalarMul(A.c + jitter, A.shape, A.dtype, A.device)
+
+
+@overload
+def _add_jitter(A: Identity, jitter: ScalarFloat) -> ScalarMul:  # pyright: ignore[reportOverlappingOverload]
+    return ScalarMul(1.0 + jitter, A.shape, A.dtype, A.device)
+
+
+@overload
+def _add_jitter(  # pyright: ignore[reportOverlappingOverload]
+    A: ScalarMul | Diagonal | Identity, jitter: ScalarFloat | Float[Array, "N"]
+) -> Diagonal:
+    return Diagonal(cola.linalg.diag(A) + jitter)
+
+
+@cola.dispatch
+def _add_jitter(A: Any, jitter: Any) -> Any:
+    pass

--- a/src/cagpjax/operators/diag_like.py
+++ b/src/cagpjax/operators/diag_like.py
@@ -22,4 +22,5 @@ def diag_like(
     if jnp.isscalar(values):
         return ScalarMul(values, operator.shape, dtype=dtype, device=device)
     else:
-        return Diagonal(values.astype(dtype)).to(device)
+        values = values.astype(dtype).to_device(device)
+        return Diagonal(values)

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -21,6 +21,12 @@ class PseudoInverse(AbstractLinearSolverMethod):
     rank of $A$ is dependent on hyperparameters being optimized, because the
     pseudoinverse is discontinuous, the optimization problem may be ill-posed.
 
+    Note that if $A$ is (almost-)degenerate (some eigenvalues repeat), then
+    the gradient of its solves in JAX may be non-computable or numerically unstable
+    (see [jax#669](https://github.com/jax-ml/jax/issues/669)).
+    In this case adding a small amount of random `jitter` to the diagonal can
+    significantly improve stability.
+
     Attributes:
         rtol: Specifies the cutoff for small eigenvalues.
               Eigenvalues smaller than `rtol * largest_nonzero_eigenvalue` are treated as zero.

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -200,7 +200,7 @@ class TestSolvers:
 
         grad_fn = jax.grad(loss_fn)
         grad = grad_fn(A.to_dense())
-        
+
         if jitter is None:
             assert not jnp.isfinite(grad).all()
         else:


### PR DESCRIPTION
For degenerate-by-construction or degenerate-due-to-floating-point-error Hermitian matrices (degenerate meaning has at least 1 eigenvalue that repeats), JAX can't currently compute finite gradients of functions that depend at all on the eigenvectors via `eigh` (see jax-ml/jax#669).

As a workaround, this PR adds the ability to add a small amount of random jitter to the diagonal of PSD operators before eigendecomposing them.