### PR TITLE
Make eigh VJP more robust for almost-zero gradients

### DIFF
--- a/src/cagpjax/linalg/eigh.py
+++ b/src/cagpjax/linalg/eigh.py
@@ -184,11 +184,11 @@ def _eigh_safe_rev(
                 if grad_rtol == 0.0
                 else jnp.abs(eigvals).max(axis=-1) * grad_rtol
             )
-            grad_thresh = (
-                grad_rtol if grad_rtol == 0.0 else jnp.abs(vt_grad_v).max() * grad_rtol
-            )
+            # use 1.0 as reference for rtol check for gradient so that we don't
+            # count a very low (e.g. 1e-30) value as being greater than zero
+            # when the largest gradient value is also very low.
             inv_mask = (
-                (jnp.abs(w_diff) <= w_thresh) & (jnp.abs(vt_grad_v) <= grad_thresh)
+                (jnp.abs(w_diff) <= w_thresh) & (jnp.abs(vt_grad_v) <= grad_rtol)
             ).astype(eigvals.dtype)
         else:
             inv_mask = jnp.eye(eigvals.shape[-1], dtype=eigvals.dtype)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -230,21 +230,7 @@ class TestEigh:
         else:
             assert jnp.isfinite(grad).all()
 
-    @pytest.mark.parametrize(
-        "grad_rtol",
-        [
-            None,
-            pytest.param(
-                1e-9,
-                marks=[
-                    pytest.mark.xfail(
-                        reason="Gradient is close to zero everywhere, so rtol for identifying "
-                        + "zero gradient fails."
-                    )
-                ],
-            ),
-        ],
-    )
+    @pytest.mark.parametrize("grad_rtol", [None, 1e-9])
     @pytest.mark.parametrize("dtype", [jnp.float64])
     def test_eigh_gradient_degenerate_zero_grad(self, grad_rtol, dtype):
         """Test computation of almost-zero gradient with degenerate eigenvalues."""

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -235,10 +235,10 @@ class TestEigh:
         [
             None,
             pytest.param(
-                0.0,
+                1e-9,
                 marks=[
                     pytest.mark.xfail(
-                        message="Gradient is close to zero everywhere, so rtol for identifying "
+                        reason="Gradient is close to zero everywhere, so rtol for identifying "
                         + "zero gradient fails."
                     )
                 ],


### PR DESCRIPTION
Using `grad_rtol` as an rtol as here https://github.com/sethaxen/CAGPJax/blob/9bbd000c3ae05878a0fc38ceeba28f3b05766622/src/cagpjax/linalg/eigh.py#L187-L192 is problematic when the gradient wrt the eigenvectors is almost-zero. e.g. if `jnp.abs(vt_grad_v).max() == 1e-30` and `vt_grad_v[i,j] = 1e-30`, then one needs a `grad_rtol` of 1 to detect the gradient at `[i,j]` as being 0 and correctly mask that value. This is simply too loose of a check and makes it nearly impossible to improve stability for some almost-degenerate matrices. I'm not certain what the best reference value would be to compare to, so this PR chooses 1.0 as the reference, using the rtol as an atol.