### PR TITLE
Redefine congruence_transform and BlockDiagonalSparse

### DIFF
--- a/src/cagpjax/linalg/congruence.py
+++ b/src/cagpjax/linalg/congruence.py
@@ -14,7 +14,7 @@ from ..operators import BlockDiagonalSparse
 # fallback to plain multiplication
 @overload
 def congruence_transform(A: Any, B: Any) -> Any:
-    return (A @ B) @ A.T
+    return A.T @ (B @ A)
 
 
 @overload
@@ -45,7 +45,7 @@ def congruence_transform(A: BlockDiagonalSparse, B: Diagonal | ScalarMul) -> Dia
 
 @cola.dispatch
 def congruence_transform(A: Any, B: Any) -> Any:
-    """Congruence transformation ``A @ B @ A.T``.
+    """Congruence transformation ``A.T @ B @ A``.
 
     Args:
         A: Linear operator or array to be applied.

--- a/src/cagpjax/linalg/congruence.py
+++ b/src/cagpjax/linalg/congruence.py
@@ -26,7 +26,7 @@ def congruence_transform(A: Diagonal, B: Diagonal) -> Diagonal:  # pyright: igno
 def congruence_transform(A: BlockDiagonalSparse, B: Diagonal | ScalarMul) -> Diagonal:  # pyright: ignore[reportOverlappingOverload]
     nz_values = B @ A.nz_values**2
 
-    n_blocks, n = A.shape
+    n, n_blocks = A.shape
     block_size = n // n_blocks
     n_blocks_main = n_blocks if n % n_blocks == 0 else n_blocks - 1
     n_main = n_blocks_main * block_size

--- a/src/cagpjax/operators/block_diagonal_sparse.py
+++ b/src/cagpjax/operators/block_diagonal_sparse.py
@@ -9,7 +9,7 @@ class BlockDiagonalSparse(LinearOperator):
     """Block-diagonal sparse linear operator.
 
     This operator represents a block-diagonal matrix structure where the blocks are contiguous, and
-    each contains a row vector, so that exactly one value is non-zero in each column.
+    each contains a column vector, so that exactly one value is non-zero in each row.
 
     Args:
         nz_values: Non-zero values to be distributed across diagonal blocks.
@@ -25,42 +25,75 @@ class BlockDiagonalSparse(LinearOperator):
     >>> nz_values = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
     >>> op = BlockDiagonalSparse(nz_values, n_blocks=3)
     >>> print(op.shape)
-    (3, 6)
+    (6, 3)
     >>>
-    >>> # Apply to a vector
-    >>> x = jnp.ones(6)
-    >>> result = op @ x
+    >>> # Apply to identity matrices
+    >>> op @ jnp.eye(3)
+    Array([[1., 0., 0.],
+           [2., 0., 0.],
+           [0., 3., 0.],
+           [0., 4., 0.],
+           [0., 0., 5.],
+           [0., 0., 6.]], dtype=float32)
     ```
     """
 
     def __init__(self, nz_values: Float[Array, "N"], n_blocks: int):
         n = nz_values.shape[0]
-        super().__init__(nz_values.dtype, (n_blocks, n))
+        super().__init__(nz_values.dtype, (n, n_blocks))
         self.nz_values = nz_values
 
-    def _matmat(self, X: Float[Array, "N #M"]) -> Float[Array, "K #M"]:
-        # figure out size of main blocks
-        n_blocks, n = self.shape
+    def _matmat(self, X: Float[Array, "K M"]) -> Float[Array, "N M"]:
+        n, n_blocks = self.shape
         block_size = n // n_blocks
         n_blocks_main = n_blocks if n % n_blocks == 0 else n_blocks - 1
         n_main = n_blocks_main * block_size
+        m = X.shape[1]
 
         # block-wise multiplication for main blocks
         if n_blocks_main > 0:
             blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
-            X_main = X[:n_main, ...].reshape(n_blocks_main, block_size, -1)
-            res_main = jnp.einsum("ik,ikj->ij", blocks_main, X_main)
+            X_main = X[:n_blocks_main, :]
+            res_main = (blocks_main[..., None] * X_main[:, None, :]).reshape(n_main, m)
         else:
-            res_main = jnp.empty((0, *X.shape[1:]), dtype=X.dtype)
+            res_main = jnp.empty((0, m), dtype=X.dtype)
 
         # handle overhang if any
         if n > n_main:
             n_overhang = n - n_main
-            X_overhang = X[n_main:, ...].reshape(n_overhang, -1)
+            X_overhang = X[n_blocks_main, :]
             block_overhang = self.nz_values[n_main:]
-            res_overhang = block_overhang[None, :] @ X_overhang
+            res_overhang = jnp.outer(block_overhang, X_overhang).reshape(n_overhang, m)
             res = jnp.concatenate([res_main, res_overhang], axis=0)
         else:
             res = res_main
 
-        return res.reshape(-1, *X.shape[1:])
+        return res
+
+    def _rmatmat(self, X: Float[Array, "M N"]) -> Float[Array, "M K"]:
+        # figure out size of main blocks
+        n, n_blocks = self.shape
+        block_size = n // n_blocks
+        n_blocks_main = n_blocks if n % n_blocks == 0 else n_blocks - 1
+        n_main = n_blocks_main * block_size
+        m = X.shape[0]
+
+        # block-wise multiplication for main blocks
+        if n_blocks_main > 0:
+            blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
+            X_main = X[:, :n_main].reshape(m, n_blocks_main, block_size)
+            res_main = jnp.einsum("ik,jik->ji", blocks_main, X_main)
+        else:
+            res_main = jnp.empty((m, 0), dtype=X.dtype)
+
+        # handle overhang if any
+        if n > n_main:
+            n_overhang = n - n_main
+            X_overhang = X[:, n_main:].reshape(m, n_overhang)
+            block_overhang = self.nz_values[n_main:]
+            res_overhang = (X_overhang @ block_overhang)[:, None]
+            res = jnp.concatenate([res_main, res_overhang], axis=1)
+        else:
+            res = res_main
+
+        return res

--- a/src/cagpjax/operators/block_diagonal_sparse.py
+++ b/src/cagpjax/operators/block_diagonal_sparse.py
@@ -51,12 +51,9 @@ class BlockDiagonalSparse(LinearOperator):
         m = X.shape[1]
 
         # block-wise multiplication for main blocks
-        if n_blocks_main > 0:
-            blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
-            X_main = X[:n_blocks_main, :]
-            res_main = (blocks_main[..., None] * X_main[:, None, :]).reshape(n_main, m)
-        else:
-            res_main = jnp.empty((0, m), dtype=X.dtype)
+        blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
+        X_main = X[:n_blocks_main, :]
+        res_main = (blocks_main[..., None] * X_main[:, None, :]).reshape(n_main, m)
 
         # handle overhang if any
         if n > n_main:
@@ -79,12 +76,9 @@ class BlockDiagonalSparse(LinearOperator):
         m = X.shape[0]
 
         # block-wise multiplication for main blocks
-        if n_blocks_main > 0:
-            blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
-            X_main = X[:, :n_main].reshape(m, n_blocks_main, block_size)
-            res_main = jnp.einsum("ik,jik->ji", blocks_main, X_main)
-        else:
-            res_main = jnp.empty((m, 0), dtype=X.dtype)
+        blocks_main = self.nz_values[:n_main].reshape(n_blocks_main, block_size)
+        X_main = X[:, :n_main].reshape(m, n_blocks_main, block_size)
+        res_main = jnp.einsum("ik,jik->ji", blocks_main, X_main)
 
         # handle overhang if any
         if n > n_main:

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -82,6 +82,6 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
             A: Linear operator (unused).
 
         Returns:
-            Transposed[BlockDiagonalSparse]: Sparse action structure representing the blocks.
+            BlockDiagonalSparse: Sparse action structure representing the blocks.
         """
-        return BlockDiagonalSparse(self.nz_values.value, self.n_actions).T
+        return BlockDiagonalSparse(self.nz_values.value, self.n_actions)

--- a/src/cagpjax/solvers/base.py
+++ b/src/cagpjax/solvers/base.py
@@ -37,9 +37,9 @@ class AbstractLinearSolver(nnx.Module):
 
     @abstractmethod
     def inv_congruence_transform(
-        self, B: LinearOperator | Float[Array, "K N"]
+        self, B: LinearOperator | Float[Array, "N K"]
     ) -> LinearOperator | Float[Array, "K K"]:
-        """Compute the inverse congruence transform $B x$ for $x$ in $Ax = B^T$.
+        """Compute the inverse congruence transform $B^T x$ for $x$ in $Ax = B$.
 
         Arguments:
             B: Linear operator or array to be applied.
@@ -55,7 +55,7 @@ class AbstractLinearSolver(nnx.Module):
         Arguments:
             b: Right-hand side of the linear system.
         """
-        return self.inv_congruence_transform(b.reshape(1, -1)).squeeze()
+        return self.inv_congruence_transform(b[:, None]).squeeze()
 
     @abstractmethod
     def trace_solve(self, B: Self) -> ScalarFloat:

--- a/src/cagpjax/solvers/cholesky.py
+++ b/src/cagpjax/solvers/cholesky.py
@@ -55,10 +55,10 @@ class CholeskySolver(AbstractLinearSolver):
 
     @override
     def inv_congruence_transform(
-        self, B: LinearOperator | Float[Array, "N K"]
+        self, B: LinearOperator | Float[Array, "K N"]
     ) -> LinearOperator | Float[Array, "K K"]:
         Linv = cola.linalg.inv(self.lchol)
-        right_term = Linv @ B.T
+        right_term = Linv @ B
         return right_term.T @ right_term
 
     @override

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -113,11 +113,11 @@ class PseudoInverseSolver(AbstractLinearSolver):
 
     @override
     def inv_congruence_transform(
-        self, B: LinearOperator | Float[Array, "N K"]
+        self, B: LinearOperator | Float[Array, "K N"]
     ) -> LinearOperator | Float[Array, "K K"]:
         eigenvectors = self.eigh_result.eigenvectors
-        z = B @ eigenvectors
-        z = z @ cola.ops.Diagonal(self.eigvals_inv) @ z.T
+        z = eigenvectors.T @ B
+        z = z.T @ cola.ops.Diagonal(self.eigvals_inv) @ z
         return z
 
     @override

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -25,7 +25,7 @@ class TestCongruenceTransform:
     ):
         """Test fallback case where ``A`` and ``B`` can be linear operators or dense arrays."""
         key, subkey = jax.random.split(key)
-        A_dense = jax.random.normal(key, (m, n), dtype=dtype)
+        A_dense = jax.random.normal(key, (n, m), dtype=dtype)
         B_dense = jax.random.normal(subkey, (n, n), dtype=dtype)
         A = A_wrap(A_dense)
         B = B_wrap(B_dense)
@@ -39,7 +39,7 @@ class TestCongruenceTransform:
             assert isinstance(C, jnp.ndarray)
             C_dense = C
 
-        assert jnp.allclose(C_dense, A_dense @ B_dense @ A_dense.T)
+        assert jnp.allclose(C_dense, A_dense.T @ B_dense @ A_dense)
 
     @pytest.mark.parametrize("n", [3, 6])
     def test_congruence_both_diagonal(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -47,9 +47,9 @@ class TestBlockDiagonalSparse:
 
     @pytest.fixture(
         params=[
-            (5, 2),  # has overhang
-            (9, 4),  # has overhang
-            (6, 3),  # no overhang
+            pytest.param((5, 2), id="has_overhang"),
+            pytest.param((9, 4), id="has_overhang"),
+            pytest.param((6, 3), id="no_overhang"),
         ]
     )
     def shape(self, request):

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -184,8 +184,7 @@ class TestBlockSparsePolicy:
         policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
         _test_batch_policy_actions_consistency(policy, psd_linear_operator)
         action = policy.to_actions(psd_linear_operator)
-        assert isinstance(action, Transpose)
-        assert isinstance(action.T, BlockDiagonalSparse)
+        assert isinstance(action, BlockDiagonalSparse)
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     def test_to_actions_reproducible(

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -144,7 +144,7 @@ class TestSolvers:
         self, solver, n, m, dtype, B_type, key=jax.random.key(23)
     ):
         """Test inv_congruence_transform is consistent with solve and congruence_transform."""
-        B = jax.random.normal(key, (m, n), dtype=dtype)
+        B = jax.random.normal(key, (n, m), dtype=dtype)
         if B_type == cola.ops.LinearOperator:
             B = cola.lazify(B)
 


### PR DESCRIPTION
This PR updates the definitions of `congruence_transform` so that its first argument is transposed (compared to the current definition) and also updates `BlockDiagonalSparse` to be the transpose of the current definition. These changes allow us to avoid transposing the actions operator when combining it with other operators. Since cola generally discards annotations when transposing, and since we can't dispatch easily on the transposed form of a custom operator, these changes make it easier to implement performance operators down the line without changing core functionality.