### PR TITLE
chore: Fix gpjax version to <0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ urls = {repository = "https://github.com/sethaxen/CAGPJax" }
 
 dependencies = [
     "jax>=0.5,<0.6",
-    "gpjax",
+    "gpjax<0.12",
     "jaxtyping",
     "cola-ml>=0.0.7",
     "flax>=0.10.0",


### PR DESCRIPTION
gpjax v0.12 removed support for cola and removed `Static`, which we internally use, so this PR sets the gpjax compat to only versions less than v0.12.