### PR TITLE
chore: Bump flax compat to v0.11 and remove jax upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 urls = {repository = "https://github.com/sethaxen/CAGPJax" }
 
 dependencies = [
-    "jax>=0.5,<0.8",
+    "jax>=0.5",
     "gpjax<0.13",
     "jaxtyping",
     "cola-ml>=0.0.7",


### PR DESCRIPTION
This PR just updates the compat bounds. All tests pass against the latest compatible versions.