### PR TITLE
refactor: Make solvers abstract base classes

### DIFF
--- a/src/cagpjax/solvers/base.py
+++ b/src/cagpjax/solvers/base.py
@@ -1,6 +1,6 @@
 """Base classes for linear solvers and methods."""
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from cola.ops import LinearOperator
 from flax import nnx
@@ -10,7 +10,7 @@ from typing_extensions import Self
 from ..typing import ScalarFloat
 
 
-class AbstractLinearSolver(nnx.Module):
+class AbstractLinearSolver(ABC):
     """
     Base class for linear solvers.
 


### PR DESCRIPTION
Solvers are currently `nnx.Module`s. In Flax v0.12, modules are much more strict about what their attributes can be, so we can't have e.g. `LinearOperator` or `Eigh` be attributes of our solvers.

The solution for this is to note that we should only use `nnx.Module`s for objects whose state is entirely determined by a chain of `nnx.Module`s ultimately terminating in `nnx.Variable`s for parameters that might be changed. The solvers themselves are generated by the `AbstractLinearSolverMethod`s internally and should never be passed as input to an optimization objective, so we can treat them purely as convenience objects used within such objectives. It's thus not necessary that they be `Module`s at all, so we can just make them abstract base classes.