### PR TITLE
chore: Remove gpjax and flax compat upper bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ urls = {repository = "https://github.com/sethaxen/CAGPJax" }
 
 dependencies = [
     "jax>=0.5",
-    "gpjax<0.13",
+    "gpjax",
     "jaxtyping",
     "cola-ml>=0.0.7",
     "flax>=0.10.0",


### PR DESCRIPTION
With #18 all tests now pass on the latest versions of gpjax and flax, so this PR removes the compat upper bounds.