### PR TITLE
fix: Remove deprecated nnx.Variable .value access

### DIFF
--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -89,12 +89,10 @@ class ComputationAwareGP(AbstractComputationAwareGP):
         mean_prior = prior.mean_function(x).squeeze()
         # Work around GPJax promoting dtype of mean to float64 (See JaxGaussianProcesses/GPJax#523)
         if isinstance(prior.mean_function, Constant):
-            constant = prior.mean_function.constant
-            if isinstance(constant, nnx.Variable):
-                constant = constant.value
+            constant = prior.mean_function.constant[...]
             mean_prior = mean_prior.astype(constant.dtype)
         cov_xx = lazify(prior.kernel.gram(x))
-        obs_cov = diag_like(cov_xx, likelihood.obs_stddev.value**2)
+        obs_cov = diag_like(cov_xx, likelihood.obs_stddev[...] ** 2)
         cov_prior = cov_xx + obs_cov
 
         # Project quantities to subspace
@@ -149,9 +147,7 @@ class ComputationAwareGP(AbstractComputationAwareGP):
         mean_z = prior.mean_function(z).squeeze()
         # Work around GPJax promoting dtype of mean to float64 (See JaxGaussianProcesses/GPJax#523)
         if isinstance(prior.mean_function, Constant):
-            constant = prior.mean_function.constant
-            if isinstance(constant, nnx.Variable):
-                constant = constant.value
+            constant = prior.mean_function.constant[...]
             mean_z = mean_z.astype(constant.dtype)
         cov_zz = lazify(prior.kernel.gram(z))
         cov_zx = cov_zz if test_inputs is None else prior.kernel.cross_covariance(z, x)

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -84,4 +84,4 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         Returns:
             BlockDiagonalSparse: Sparse action structure representing the blocks.
         """
-        return BlockDiagonalSparse(self.nz_values.value, self.n_actions)
+        return BlockDiagonalSparse(self.nz_values[...], self.n_actions)

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -57,13 +57,6 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
     def n_actions(self):
         return self.pseudo_inputs.shape[0]
 
-    @property
-    def _pseudo_inputs(self) -> Float[Array, "M D"]:
-        if isinstance(self.pseudo_inputs, Parameter):
-            return self.pseudo_inputs.value
-        else:
-            return self.pseudo_inputs
-
     def to_actions(self, A: LinearOperator) -> LinearOperator:
-        S = self.kernel.cross_covariance(self.train_inputs, self._pseudo_inputs)
+        S = self.kernel.cross_covariance(self.train_inputs, self.pseudo_inputs[...])
         return cola.lazify(S)

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -156,8 +156,8 @@ class TestBlockSparsePolicy:
 
         assert policy.n_actions == n_actions
         assert isinstance(policy.nz_values, Real)
-        assert policy.nz_values.value.shape == (n,)
-        assert policy.nz_values.value.dtype == dtype
+        assert policy.nz_values.shape == (n,)
+        assert policy.nz_values.dtype == dtype
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
@@ -171,15 +171,15 @@ class TestBlockSparsePolicy:
         policy = BlockSparsePolicy(n_actions=n_actions, nz_values=nz_values)
         assert policy.n_actions == n_actions
         assert isinstance(policy.nz_values, Real)
-        assert policy.nz_values.value.dtype == dtype
-        assert jnp.allclose(policy.nz_values.value, nz_values)
+        assert policy.nz_values.dtype == dtype
+        assert jnp.allclose(policy.nz_values[...], nz_values)
 
         policy_static = BlockSparsePolicy(
             n_actions=n_actions, nz_values=Real(nz_values)
         )
         assert isinstance(policy_static.nz_values, Real)
-        assert policy_static.nz_values.value.dtype == dtype
-        assert jnp.allclose(policy_static.nz_values.value, nz_values)
+        assert policy_static.nz_values.dtype == dtype
+        assert jnp.allclose(policy_static.nz_values[...], nz_values)
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     def test_to_actions_consistency(
@@ -263,7 +263,7 @@ class TestPseudoInputPolicy:
         assert isinstance(policy.train_inputs, jnp.ndarray)
         assert jnp.array_equal(policy.train_inputs, train_inputs)
         assert isinstance(policy.pseudo_inputs, pseudo_input_type)
-        assert jnp.array_equal(policy._pseudo_inputs, pseudo_inputs)
+        assert jnp.array_equal(policy.pseudo_inputs[...], pseudo_inputs)
 
     def test_actions_is_cross_covariance(self, inputs, kernel, dtype):
         """Test actions are the cross-covariance between the training inputs and pseudo-inputs."""


### PR DESCRIPTION
flax has deprecated access of `nnx.Variable`s via `.value`. Instead, if a variable wraps a `jax.array`, then one should access with `[...]`. Since this indexing also works on `jax.array`s directly, using this actually simplifies the code in a few places.

Note that since gpjax still uses the deprecated syntax, we will for now still get some deprecation warnings.