### PR TITLE
Fix: Fix pre-commit errors, upperbound jax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 urls = {repository = "https://github.com/sethaxen/CAGPJax" }
 
 dependencies = [
-    "jax>=0.5",
+    "jax>=0.5,<0.10.0",
     "gpjax",
     "jaxtyping",
     "cola-ml>=0.0.7",

--- a/src/cagpjax/distributions.py
+++ b/src/cagpjax/distributions.py
@@ -17,7 +17,6 @@ class GaussianDistribution(Distribution):
 
     loc: Float[Array, " N"]
     scale: LinearOperator
-    support = constraints.real_vector
     solver: AbstractLinearSolver
 
     def __init__(
@@ -40,6 +39,11 @@ class GaussianDistribution(Distribution):
         event_shape = jnp.shape(self.loc)
         self.solver = solver
         super().__init__(batch_shape, event_shape, **kwargs)
+
+    @property
+    def support(self):
+        """Support of the distribution."""
+        return constraints.real_vector
 
     @property
     def mean(self) -> Float[Array, " N"]:

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -3,6 +3,7 @@
 import cola
 import jax
 import jax.numpy as jnp
+import jax.test_util
 import pytest
 from cola.ops import Dense, Diagonal, Identity, LinearOperator, ScalarMul, Triangular
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 import gpjax as gpjax
 import jax
 import jax.numpy as jnp
+import jax.test_util
 import pytest
 from flax import nnx
 from gpjax.gps import ConjugatePosterior

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -4,6 +4,7 @@ import cola
 import gpjax
 import jax
 import jax.numpy as jnp
+import jax.test_util
 import numpy as np
 import pytest
 from cola.ops import Dense, Diagonal, LinearOperator, ScalarMul


### PR DESCRIPTION
This PR fixes CI failures due to changes made in recent dependency versions.

The jax upperbound to <v0.10.0 should be removed when pyro-ppl/numpyro#2173 is merged and released.