### PR TITLE
feat!: Move to GPJax v0.14

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jax.config.update("jax_enable_x64", True)
 
 n_data = 1_000
 
-# Build_model
+# Build model
 prior = gpx.gps.Prior(
     mean_function=gpx.mean_functions.Zero(),
     kernel=gpx.kernels.RBF(lengthscale=1.0, variance=1.0),
@@ -56,7 +56,7 @@ def negative_elbo(cagp, train_data):
 
 cagp_optimized, history = gpx.fit(
     model=cagp,
-    objective=negative_elbo, 
+    objective=negative_elbo,
     train_data=train_data,
     optim=ox.adamw(learning_rate=0.01),
     num_iters=250,

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ train_data = gpx.Dataset(x_train, y_train)
 key, subkey = jax.random.split(key)
 policy = cagpjax.policies.BlockSparsePolicy(n_actions=10, n=n_data, key=subkey)
 cagp = cagpjax.models.ComputationAwareGP(posterior, policy)
+key, actions_key = jax.random.split(key)
 
 # Optimize hyperparameters (including actions)
 def negative_elbo(cagp, train_data):
-    cagp_state = cagp.init(train_data)  # compute state conditioned on data
+    cagp_state = cagp.init(train_data, key=actions_key)  # compute state conditioned on data
     return -cagp.elbo(cagp_state)
 
 cagp_optimized, history = gpx.fit(
@@ -64,7 +65,7 @@ cagp_optimized, history = gpx.fit(
 )
 
 # Get CaGP posterior distribution at the inputs
-cagp_state = cagp_optimized.init(train_data)
+cagp_state = cagp_optimized.init(train_data, key=actions_key)
 cagp_post = cagp_optimized.predict(cagp_state)
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import optax as ox
 jax.config.update("jax_enable_x64", True)
 
 n_data = 1_000
+n_actions = 10
 
 # Build model
 prior = gpx.gps.Prior(
@@ -45,8 +46,10 @@ y_train = (y_train + jax.random.normal(subkey, y_train.shape)).reshape(-1, 1)
 train_data = gpx.Dataset(x_train, y_train)
 
 # Condition a CaGP with an (untrained) sparse linear solver policy
-key, subkey = jax.random.split(key)
-policy = cagpjax.policies.BlockSparsePolicy(n_actions=10, n=n_data, key=subkey)
+key, policy_key = jax.random.split(key)
+policy = cagpjax.policies.BlockSparsePolicy.from_random(
+    policy_key, n_data, n_actions,
+)
 cagp = cagpjax.models.ComputationAwareGP(posterior, policy)
 key, actions_key = jax.random.split(key)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cagpjax"
 version = "0.1.0"
 description = "Computation-Aware Gaussian Processes for JAX"
 readme = "README.md"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.11, <3.14"
 license = {file = "LICENSE"}
 authors = [
     { name = "Seth Axen", email = "seth@sethaxen.com" },
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "gpjax>=0.14.0rc1",
     "jaxtyping",
     "cola-ml>=0.0.7",
-    "flax>=0.10.0",
     "equinox>=0.11.0",
     "lineax>=0.0.6",
     "paramax>=0.0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ urls = {repository = "https://github.com/sethaxen/CAGPJax" }
 
 dependencies = [
     "jax>=0.5,<0.10.0",
-    "gpjax",
+    "gpjax>=0.14.0rc1",
     "jaxtyping",
     "cola-ml>=0.0.7",
     "flax>=0.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "jaxtyping",
     "cola-ml>=0.0.7",
     "flax>=0.10.0",
+    "equinox>=0.11.0",
+    "lineax>=0.0.6",
+    "paramax>=0.0.5",
     "typing-extensions",
     "matfree>=0.1.0",
 ]

--- a/src/cagpjax/computations/lazy.py
+++ b/src/cagpjax/computations/lazy.py
@@ -2,11 +2,13 @@
 
 import cola
 import jax.numpy as jnp
+import lineax as lx
 from gpjax.kernels import AbstractKernel
 from gpjax.kernels.computations import AbstractKernelComputation, DenseKernelComputation
 from jaxtyping import Array, Float
 from typing_extensions import override
 
+from ..interop import ColaLinearOperator
 from ..operators import LazyKernel
 
 
@@ -84,8 +86,12 @@ class LazyKernelComputation(AbstractKernelComputation):
         self.checkpoint = checkpoint
 
     @override
-    def gram(self, kernel: AbstractKernel, x: Float[Array, "N D"]) -> LazyKernel:  # pyright: ignore[reportIncompatibleMethodOverride]
-        return cola.PSD(
+    def gram(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+        kernel: AbstractKernel,
+        x: Float[Array, "N D"],
+    ) -> lx.AbstractLinearOperator:
+        op = cola.PSD(
             LazyKernel(
                 kernel,
                 x,
@@ -95,6 +101,9 @@ class LazyKernelComputation(AbstractKernelComputation):
                 checkpoint=self.checkpoint,
             )
         )
+        return lx.TaggedLinearOperator(
+            ColaLinearOperator(op), lx.positive_semidefinite_tag
+        )
 
     @override
     def cross_covariance(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -102,12 +111,14 @@ class LazyKernelComputation(AbstractKernelComputation):
         kernel: AbstractKernel,
         x1: Float[Array, "N D"],
         x2: Float[Array, "M D"],
-    ) -> Float[Array, "N M"] | LazyKernel:
-        return LazyKernel(
-            kernel,
-            x1,
-            x2,
-            batch_size=self.batch_size,
-            max_memory_mb=self.max_memory_mb,
-            checkpoint=self.checkpoint,
+    ) -> Float[Array, "N M"] | lx.AbstractLinearOperator:
+        return ColaLinearOperator(
+            LazyKernel(
+                kernel,
+                x1,
+                x2,
+                batch_size=self.batch_size,
+                max_memory_mb=self.max_memory_mb,
+                checkpoint=self.checkpoint,
+            )
         )

--- a/src/cagpjax/interop.py
+++ b/src/cagpjax/interop.py
@@ -10,6 +10,40 @@ from cola.ops import LinearOperator
 from jaxtyping import Array, Float, PyTree
 
 
+class ColaLinearOperator(lx.AbstractLinearOperator):
+    """Wrap a cola operator with a Lineax-compatible interface."""
+
+    operator: LinearOperator
+
+    def __init__(self, operator: LinearOperator):
+        self.operator = operator
+
+    def mv(self, vector: Float[Array, " N"]) -> Float[Array, " M"]:
+        return self.operator @ vector
+
+    def as_matrix(self) -> Float[Array, "M N"]:
+        return cola.densify(self.operator)
+
+    def transpose(self) -> "ColaLinearOperator":
+        return ColaLinearOperator(self.operator.T)
+
+    def in_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return jax.ShapeDtypeStruct((self.operator.shape[1],), self.operator.dtype)
+
+    def out_structure(self) -> PyTree[jax.ShapeDtypeStruct]:
+        return jax.ShapeDtypeStruct((self.operator.shape[0],), self.operator.dtype)
+
+
+@lx.is_symmetric.register(ColaLinearOperator)
+def _(operator: ColaLinearOperator) -> bool:
+    return operator.operator.isa(cola.PSD)
+
+
+@lx.is_positive_semidefinite.register(ColaLinearOperator)
+def _(operator: ColaLinearOperator) -> bool:
+    return operator.operator.isa(cola.PSD)
+
+
 def lazify(A: Any) -> LinearOperator:
     """Convert GPJax/Lineax/array inputs into cola operators."""
     if isinstance(A, LinearOperator):

--- a/src/cagpjax/interop.py
+++ b/src/cagpjax/interop.py
@@ -1,3 +1,5 @@
+"""Interop utilities between cola and lineax operators."""
+
 from typing import Any
 
 import cola
@@ -5,12 +7,15 @@ import cola.ops
 import jax
 import lineax as lx
 from cola.ops import LinearOperator
+from jaxtyping import Array, Float, PyTree
 
 
 def lazify(A: Any) -> LinearOperator:
-    """Convert GPJax/Lineax/array inputs into Cola operators."""
+    """Convert GPJax/Lineax/array inputs into cola operators."""
     if isinstance(A, LinearOperator):
         return A
+    if isinstance(A, ColaLinearOperator):
+        return A.operator
     if isinstance(A, lx.TaggedLinearOperator):
         op = lazify(A.operator)
         if lx.positive_semidefinite_tag in A.tags:
@@ -37,4 +42,6 @@ def to_lineax(A: Any) -> lx.AbstractLinearOperator:
     if isinstance(A, cola.ops.Identity):
         metadata = jax.ShapeDtypeStruct((A.shape[1],), A.dtype)
         return lx.IdentityLinearOperator(metadata)
-    return lx.MatrixLinearOperator(cola.densify(A))
+    if isinstance(A, cola.ops.LinearOperator):
+        return ColaLinearOperator(A)
+    return lx.MatrixLinearOperator(A)

--- a/src/cagpjax/linalg/eigh.py
+++ b/src/cagpjax/linalg/eigh.py
@@ -72,8 +72,7 @@ def eigh(
         alg: Algorithm for eigenvalue decomposition.
         grad_rtol: Specifies the cutoff for similar eigenvalues, used to improve
             gradient computation for (almost-)degenerate matrices.
-            If not provided, the default is 0.0.
-            If None or negative, all eigenvalues are treated as distinct.
+            If None (default), all eigenvalues are treated as distinct.
 
     Returns:
         A named tuple of `(eigenvalues, eigenvectors)` where `eigenvectors` is a
@@ -89,6 +88,8 @@ def eigh(
     """
     if grad_rtol is None:
         grad_rtol = -1.0
+    elif grad_rtol < 0.0:
+        raise ValueError("grad_rtol must be None or non-negative.")
     vals, vecs = _eigh(A, alg, grad_rtol)  # pyright: ignore[reportArgumentType]
     if vecs.shape[-1] == A.shape[-1]:
         vecs = cola.Unitary(vecs)

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -6,6 +6,7 @@ from typing import Optional
 import cola
 import equinox as eqx
 import jax.numpy as jnp
+import paramax
 from cola.ops import LinearOperator
 from gpjax.gps import ConjugatePosterior, Dataset
 from gpjax.mean_functions import Constant
@@ -111,10 +112,10 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
         mean_prior = prior.mean_function(x).squeeze()
         # Work around GPJax promoting dtype of mean to float64 (See JaxGaussianProcesses/GPJax#523)
         if isinstance(prior.mean_function, Constant):
-            constant = prior.mean_function.constant[...]
+            constant = paramax.unwrap(prior.mean_function.constant)
             mean_prior = mean_prior.astype(constant.dtype)
         cov_xx = lazify(prior.kernel.gram(x))
-        obs_cov = diag_like(cov_xx, likelihood.obs_stddev[...] ** 2)
+        obs_cov = diag_like(cov_xx, paramax.unwrap(likelihood.obs_stddev) ** 2)
         cov_prior = cov_xx + obs_cov
 
         # Project quantities to subspace
@@ -161,7 +162,7 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
         mean_z = prior.mean_function(z).squeeze()
         # Work around GPJax promoting dtype of mean to float64 (See JaxGaussianProcesses/GPJax#523)
         if isinstance(prior.mean_function, Constant):
-            constant = prior.mean_function.constant[...]
+            constant = paramax.unwrap(prior.mean_function.constant)
             mean_z = mean_z.astype(constant.dtype)
         cov_zz = lazify(prior.kernel.gram(z))
         cov_zx = cov_zz if test_inputs is None else prior.kernel.cross_covariance(z, x)

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -168,7 +168,11 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
             constant = paramax.unwrap(prior.mean_function.constant)
             mean_z = mean_z.astype(constant.dtype)
         cov_zz = lazify(prior.kernel.gram(z))
-        cov_zx = cov_zz if test_inputs is None else prior.kernel.cross_covariance(z, x)
+        cov_zx = (
+            cov_zz
+            if test_inputs is None
+            else lazify(prior.kernel.cross_covariance(z, x))
+        )
         cov_zx_proj = cov_zx @ state.actions
 
         # Posterior predictive distribution

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from typing import Optional
 
 import cola
+import equinox as eqx
 import jax.numpy as jnp
 from cola.ops import LinearOperator
-from flax import nnx
 from gpjax.gps import ConjugatePosterior, Dataset
 from gpjax.mean_functions import Constant
 from jaxtyping import Array, Float
@@ -45,7 +45,7 @@ class ComputationAwareGPState(Generic[_LinearSolverState]):
     repr_weights_proj: Float[Array, "M"]
 
 
-class ComputationAwareGP(nnx.Module, Generic[_LinearSolverState]):
+class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
     """Computation-aware Gaussian Process model.
 
     This model implements scalable GP inference by using batch linear solver

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -10,7 +10,7 @@ import paramax
 from cola.ops import LinearOperator
 from gpjax.gps import ConjugatePosterior, Dataset
 from gpjax.mean_functions import Constant
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import Generic, TypeVar
 
 from ..distributions import GaussianDistribution
@@ -86,11 +86,14 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
         self.policy = policy
         self.solver = solver
 
-    def init(self, train_data: Dataset) -> ComputationAwareGPState[_LinearSolverState]:
+    def init(
+        self, train_data: Dataset, *, key: PRNGKeyArray | None = None
+    ) -> ComputationAwareGPState[_LinearSolverState]:
         """Compute the state of the conditioned GP posterior.
 
         Args:
             train_data: The training data used to fit the GP.
+            key: Optional random key forwarded to policy action construction.
 
         Returns:
             state: State of the conditioned CaGP posterior, which stores any necessary
@@ -119,7 +122,7 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
         cov_prior = cov_xx + obs_cov
 
         # Project quantities to subspace
-        actions = self.policy.to_actions(cov_prior)
+        actions = self.policy.to_actions(cov_prior, key=key)
         obs_cov_proj = congruence_transform(actions, obs_cov)
         cov_prior_proj = congruence_transform(actions, cov_prior)
         cov_prior_proj_state = self.solver.init(cov_prior_proj)

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -14,9 +14,9 @@ from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import Generic, TypeVar
 
 from ..distributions import GaussianDistribution
+from ..interop import lazify
 from ..linalg import congruence_transform
 from ..operators import diag_like
-from ..operators.utils import lazify
 from ..policies import AbstractBatchLinearSolverPolicy
 from ..solvers import AbstractLinearSolver, Cholesky
 from ..typing import ScalarFloat

--- a/src/cagpjax/models/cagp.py
+++ b/src/cagpjax/models/cagp.py
@@ -55,7 +55,8 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
 
     Attributes:
         posterior: The original (exact) posterior.
-        policy: The batch linear solver policy.
+        policy: The batch linear solver policy that defines the subspace into
+                which the data is projected.
         solver: The linear solver method to use for solving linear systems
             with positive semi-definite operators.
 
@@ -65,26 +66,9 @@ class ComputationAwareGP(eqx.Module, Generic[_LinearSolverState]):
 
     posterior: ConjugatePosterior
     policy: AbstractBatchLinearSolverPolicy
-    solver: AbstractLinearSolver[_LinearSolverState]
-
-    def __init__(
-        self,
-        posterior: ConjugatePosterior,
-        policy: AbstractBatchLinearSolverPolicy,
-        solver: AbstractLinearSolver[_LinearSolverState] = Cholesky(1e-6),
-    ):
-        """Initialize the Computation-Aware GP model.
-
-        Args:
-            posterior: GPJax conjugate posterior.
-            policy: The batch linear solver policy that defines the subspace into
-                which the data is projected.
-            solver: The linear solver method to use for solving linear systems with
-                positive semi-definite operators.
-        """
-        self.posterior = posterior
-        self.policy = policy
-        self.solver = solver
+    solver: AbstractLinearSolver[_LinearSolverState] = eqx.field(
+        default_factory=lambda: Cholesky(1e-6)
+    )
 
     def init(
         self, train_data: Dataset, *, key: PRNGKeyArray | None = None

--- a/src/cagpjax/operators/utils.py
+++ b/src/cagpjax/operators/utils.py
@@ -1,41 +1,40 @@
 from typing import Any
 
+import cola
 import cola.ops
-import jax.numpy as jnp
+import jax
+import lineax as lx
 from cola.ops import LinearOperator
-from typing_extensions import overload
 
-try:  # support for GPJax v0.12.0
-    import gpjax.linalg  # pyright: ignore[reportMissingImports]
 
-    @overload
-    def lazify(A: gpjax.linalg.Dense) -> cola.ops.Dense:  # pyright: ignore[reportOverlappingOverload]
-        return cola.ops.Dense(A.array)
-
-    @overload
-    def lazify(A: gpjax.linalg.Diagonal) -> cola.ops.Diagonal:  # pyright: ignore[reportOverlappingOverload]
+def lazify(A: Any) -> LinearOperator:
+    """Convert GPJax/Lineax/array inputs into Cola operators."""
+    if isinstance(A, LinearOperator):
+        return A
+    if isinstance(A, lx.TaggedLinearOperator):
+        op = lazify(A.operator)
+        if lx.positive_semidefinite_tag in A.tags:
+            return cola.PSD(op)
+        return op
+    if isinstance(A, lx.MatrixLinearOperator):
+        return cola.ops.Dense(A.matrix)
+    if isinstance(A, lx.DiagonalLinearOperator):
         return cola.ops.Diagonal(A.diagonal)
-
-    @overload
-    def lazify(A: gpjax.linalg.Identity) -> cola.ops.Identity:  # pyright: ignore[reportOverlappingOverload]
-        return cola.ops.Identity(A.shape, A.dtype)
-
-    @overload
-    def lazify(A: gpjax.linalg.Triangular) -> cola.ops.Triangular:  # pyright: ignore[reportOverlappingOverload]
-        if A.lower:
-            return cola.ops.Triangular(jnp.tril(A.array), lower=True)
-        else:
-            return cola.ops.Triangular(jnp.triu(A.array), lower=False)
-
-except ImportError:
-    pass
-
-
-@overload
-def lazify(A: Any) -> cola.ops.LinearOperator:  # pyright: ignore[reportOverlappingOverload]
+    if isinstance(A, lx.IdentityLinearOperator):
+        metadata = jax.eval_shape(A.as_matrix)
+        return cola.ops.Identity(metadata.shape, metadata.dtype)
+    if isinstance(A, lx.AbstractLinearOperator):
+        return cola.lazify(A.as_matrix())
     return cola.lazify(A)
 
 
-@cola.dispatch
-def lazify(A: Any) -> Any:
-    pass
+def to_lineax(A: Any) -> lx.AbstractLinearOperator:
+    """Convert existing operators into Lineax only where GPJax requires it."""
+    if isinstance(A, lx.AbstractLinearOperator):
+        return A
+    if isinstance(A, cola.ops.Diagonal):
+        return lx.DiagonalLinearOperator(A.diag)
+    if isinstance(A, cola.ops.Identity):
+        metadata = jax.ShapeDtypeStruct((A.shape[1],), A.dtype)
+        return lx.IdentityLinearOperator(metadata)
+    return lx.MatrixLinearOperator(cola.densify(A))

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -2,6 +2,7 @@ import abc
 
 import equinox as eqx
 from cola.ops import LinearOperator
+from jaxtyping import PRNGKeyArray
 
 
 class AbstractLinearSolverPolicy(eqx.Module):
@@ -23,7 +24,9 @@ class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
         self.n_actions = n_actions
 
     @abc.abstractmethod
-    def to_actions(self, A: LinearOperator) -> LinearOperator:
+    def to_actions(
+        self, A: LinearOperator, *, key: PRNGKeyArray | None = None
+    ) -> LinearOperator:
         r"""Compute all actions used to solve the linear system $Ax=b$.
 
         For a matrix $A$ with shape ``(n, n)``, the action matrix has shape
@@ -31,6 +34,7 @@ class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
 
         Args:
             A: Linear operator representing the linear system.
+            key: Optional random key used by stochastic policies.
 
         Returns:
             Linear operator representing the action matrix.

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -14,7 +14,7 @@ class AbstractLinearSolverPolicy(eqx.Module):
     ...
 
 
-class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy, abc.ABC):
+class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
     """Abstract base class for policies that product action matrices."""
 
     @property

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -16,12 +16,13 @@ class AbstractLinearSolverPolicy(eqx.Module):
 
 
 class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
-    """Abstract base class for policies that product action matrices."""
+    """Abstract base class for policies that produce action matrices."""
 
-    n_actions: int = eqx.field(static=True)
+    n_actions: int = eqx.field(static=True, init=False)
 
-    def __init__(self, n_actions: int):
-        self.n_actions = n_actions
+    def __check_init__(self):
+        if self.n_actions < 1:
+            raise ValueError("n_actions must be at least 1")
 
     @abc.abstractmethod
     def to_actions(

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -18,7 +18,7 @@ class AbstractLinearSolverPolicy(eqx.Module):
 class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
     """Abstract base class for policies that product action matrices."""
 
-    n_actions: int
+    n_actions: int = eqx.field(static=True)
 
     def __init__(self, n_actions: int):
         self.n_actions = n_actions

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -17,11 +17,10 @@ class AbstractLinearSolverPolicy(eqx.Module):
 class AbstractBatchLinearSolverPolicy(AbstractLinearSolverPolicy):
     """Abstract base class for policies that product action matrices."""
 
-    @property
-    @abc.abstractmethod
-    def n_actions(self) -> int:
-        """Number of actions in this policy."""
-        ...
+    n_actions: int
+
+    def __init__(self, n_actions: int):
+        self.n_actions = n_actions
 
     @abc.abstractmethod
     def to_actions(self, A: LinearOperator) -> LinearOperator:

--- a/src/cagpjax/policies/base.py
+++ b/src/cagpjax/policies/base.py
@@ -1,10 +1,10 @@
 import abc
 
+import equinox as eqx
 from cola.ops import LinearOperator
-from flax import nnx
 
 
-class AbstractLinearSolverPolicy(nnx.Module):
+class AbstractLinearSolverPolicy(eqx.Module):
     r"""Abstract base class for all linear solver policies.
 
     Policies define actions used to solve a linear system $A x = b$, where $A$ is a

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -50,6 +50,7 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
             key: Random key for sampling actions if ``nz_values`` is not provided.
             **kwargs: Additional keyword arguments for ``jax.random.normal`` (e.g. ``dtype``)
         """
+        super().__init__(n_actions)
         if nz_values is None:
             if n is None:
                 raise ValueError("n must be provided if nz_values is not provided")
@@ -64,14 +65,7 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         if not isinstance(nz_values, nnx.Variable):
             nz_values = Real(nz_values)
 
-        self._n_actions: int = n_actions
         self.nz_values = nz_values
-
-    @property
-    @override
-    def n_actions(self) -> int:
-        """Number of actions to be used."""
-        return self._n_actions
 
     @override
     def to_actions(self, A: LinearOperator) -> LinearOperator:

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -4,8 +4,8 @@ import warnings
 
 import jax
 import jax.numpy as jnp
+import paramax
 from cola.ops import LinearOperator
-from gpjax.parameters import Real
 from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import override
 
@@ -31,11 +31,13 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
     These are stacked and stored as a single trainable parameter ``nz_values``.
     """
 
+    nz_values: Float[Array, "N"] | paramax.AbstractUnwrappable[Float[Array, "N"]]
+
     def __init__(
         self,
         n_actions: int,
         n: int | None = None,
-        nz_values: Float[Array, "N"] | nnx.Variable[Float[Array, "N"]] | None = None,
+        nz_values: Float[Array, "N"] | None = None,
         key: PRNGKeyArray | None = None,
         **kwargs,
     ):
@@ -58,12 +60,9 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
                 key = jax.random.PRNGKey(0)
             block_size = n // n_actions
             nz_values = jax.random.normal(key, (n,), **kwargs)
-            nz_values /= jnp.sqrt(block_size)
+            nz_values = nz_values / jnp.sqrt(block_size).astype(nz_values.dtype)
         elif n is not None:
             warnings.warn("n is ignored because nz_values is provided")
-
-        if not isinstance(nz_values, nnx.Variable):
-            nz_values = Real(nz_values)
 
         self.nz_values = nz_values
 
@@ -77,4 +76,4 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         Returns:
             BlockDiagonalSparse: Sparse action structure representing the blocks.
         """
-        return BlockDiagonalSparse(self.nz_values[...], self.n_actions)
+        return BlockDiagonalSparse(paramax.unwrap(self.nz_values), self.n_actions)

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -15,7 +15,6 @@ from ..operators import BlockDiagonalSparse
 from .base import AbstractBatchLinearSolverPolicy
 
 
-@staticmethod
 def _normalize_by_blocks(
     values: Float[Array, "N"],
     n_actions: int,

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -86,6 +86,8 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
             sampler: Callable with signature ``(key, shape, dtype) -> values``.
             dtype: Optional dtype forwarded to ``sampler``.
         """
+        if num_datapoints < 1:
+            raise ValueError("num_datapoints must be at least 1")
         nz_values = sampler(key, (num_datapoints,), dtype)
         nz_values = _normalize_by_blocks(nz_values, n_actions)
         return cls(n_actions=n_actions, nz_values=nz_values)

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -5,7 +5,6 @@ import warnings
 import jax
 import jax.numpy as jnp
 from cola.ops import LinearOperator
-from flax import nnx
 from gpjax.parameters import Real
 from jaxtyping import Array, Float, PRNGKeyArray
 from typing_extensions import override
@@ -65,8 +64,8 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         if not isinstance(nz_values, nnx.Variable):
             nz_values = Real(nz_values)
 
-        self.nz_values: nnx.Variable[Float[Array, "N"]] = nz_values
         self._n_actions: int = n_actions
+        self.nz_values = nz_values
 
     @property
     @override

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -1,7 +1,9 @@
 """Block-sparse policy."""
 
-import warnings
+from collections.abc import Callable
+from typing import Any
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import paramax
@@ -11,6 +13,33 @@ from typing_extensions import override
 
 from ..operators import BlockDiagonalSparse
 from .base import AbstractBatchLinearSolverPolicy
+
+
+@staticmethod
+def _normalize_by_blocks(
+    values: Float[Array, "N"],
+    n_actions: int,
+) -> Float[Array, "N"]:
+    n = values.shape[0]
+    block_size = n // n_actions
+    n_blocks_main = n_actions if n % n_actions == 0 else n_actions - 1
+    n_main = n_blocks_main * block_size
+
+    chunks = []
+    if n_main > 0:
+        main = values[:n_main].reshape(n_blocks_main, block_size)
+        norms = jnp.linalg.vector_norm(main, axis=1, keepdims=True)
+        main = main / jnp.where(norms > 0, norms, 1.0)
+        chunks.append(main.reshape(n_main))
+    if n > n_main:
+        overhang = values[n_main:]
+        norm = jnp.linalg.vector_norm(overhang)
+        overhang = overhang / jnp.where(norm > 0, norm, 1.0)
+        chunks.append(overhang)
+    if not chunks:
+        return values
+    return jnp.concatenate(chunks)
+
 
 
 class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
@@ -29,42 +58,39 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
     $$
 
     These are stacked and stored as a single trainable parameter ``nz_values``.
+
+    Attributes:
+        n_actions: Number of actions to use.
+        nz_values: Non-zero values of the block-diagonal sparse matrix.
     """
 
+    n_actions: int = eqx.field(static=True)
     nz_values: Float[Array, "N"] | paramax.AbstractUnwrappable[Float[Array, "N"]]
 
-    def __init__(
-        self,
+    @classmethod
+    def from_random(
+        cls,
+        key: PRNGKeyArray,
+        num_datapoints: int,
         n_actions: int,
-        n: int | None = None,
-        nz_values: Float[Array, "N"] | None = None,
-        key: PRNGKeyArray | None = None,
-        **kwargs,
-    ):
-        """Initialize the block sparse policy.
+        *,
+        sampler: Callable[
+            [PRNGKeyArray, tuple[int, ...], Any], Float[Array, " N"]
+        ] = jax.random.normal,
+        dtype: Any = None,
+    ) -> "BlockSparsePolicy":
+        """Initialize policy from block-normalized random samples.
 
         Args:
-            n_actions: Number of actions to use.
-            n: Number of rows and columns of the full operator. Must be provided if ``nz_values`` is
-                not provided.
-            nz_values: Non-zero values of the block-diagonal sparse matrix (shape ``(n,)``). If not
-                provided, random actions are sampled using the key if provided.
-            key: Random key for sampling actions if ``nz_values`` is not provided.
-            **kwargs: Additional keyword arguments for ``jax.random.normal`` (e.g. ``dtype``)
+            key: Random key used to sample initial values.
+            num_datapoints: Number of rows in the resulting operator.
+            n_actions: Number of action columns in the resulting operator.
+            sampler: Callable with signature ``(key, shape, dtype) -> values``.
+            dtype: Optional dtype forwarded to ``sampler``.
         """
-        super().__init__(n_actions)
-        if nz_values is None:
-            if n is None:
-                raise ValueError("n must be provided if nz_values is not provided")
-            if key is None:
-                key = jax.random.PRNGKey(0)
-            block_size = n // n_actions
-            nz_values = jax.random.normal(key, (n,), **kwargs)
-            nz_values = nz_values / jnp.sqrt(block_size).astype(nz_values.dtype)
-        elif n is not None:
-            warnings.warn("n is ignored because nz_values is provided")
-
-        self.nz_values = nz_values
+        nz_values = sampler(key, (num_datapoints,), dtype)
+        nz_values = _normalize_by_blocks(nz_values, n_actions)
+        return cls(n_actions=n_actions, nz_values=nz_values)
 
     @override
     def to_actions(

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -67,11 +67,14 @@ class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
         self.nz_values = nz_values
 
     @override
-    def to_actions(self, A: LinearOperator) -> LinearOperator:
+    def to_actions(
+        self, A: LinearOperator, *, key: PRNGKeyArray | None = None
+    ) -> LinearOperator:
         """Convert to block diagonal sparse action operators.
 
         Args:
             A: Linear operator (unused).
+            key: Optional random key (unused).
 
         Returns:
             BlockDiagonalSparse: Sparse action structure representing the blocks.

--- a/src/cagpjax/policies/block_sparse.py
+++ b/src/cagpjax/policies/block_sparse.py
@@ -41,7 +41,6 @@ def _normalize_by_blocks(
     return jnp.concatenate(chunks)
 
 
-
 class BlockSparsePolicy(AbstractBatchLinearSolverPolicy):
     r"""Block-sparse linear solver policy.
     

--- a/src/cagpjax/policies/lanczos.py
+++ b/src/cagpjax/policies/lanczos.py
@@ -19,20 +19,17 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
         key: Random key for reproducible Lanczos iterations.
     """
 
-    key: PRNGKeyArray | None
     grad_rtol: float | None
 
     def __init__(
         self,
         n_actions: int,
-        key: PRNGKeyArray | None = None,
         grad_rtol: float | None = 0.0,
     ):
         """Initialize the Lanczos policy.
 
         Args:
             n_actions: Number of Lanczos vectors to compute.
-            key: Random key for initialization.
             grad_rtol: Specifies the cutoff for similar eigenvalues, used to improve
                 gradient computation for (almost-)degenerate matrices.
                 If not provided, the default is 0.0.
@@ -40,20 +37,22 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
                 (see [`cagpjax.linalg.eigh`][] for more details)
         """
         super().__init__(n_actions)
-        self.key = key
         self.grad_rtol = grad_rtol
 
     @override
-    def to_actions(self, A: LinearOperator) -> LinearOperator:
+    def to_actions(
+        self, A: LinearOperator, *, key: PRNGKeyArray | None = None
+    ) -> LinearOperator:
         """Compute action matrix.
 
         Args:
             A: Symmetric linear operator representing the linear system.
+            key: Random key used to initialize the Lanczos run.
 
         Returns:
             Linear operator containing the Lanczos vectors as columns.
         """
         vecs = eigh(
-            A, alg=Lanczos(self.n_actions, key=self.key), grad_rtol=self.grad_rtol
+            A, alg=Lanczos(self.n_actions, key=key), grad_rtol=self.grad_rtol
         ).eigenvectors
         return vecs

--- a/src/cagpjax/policies/lanczos.py
+++ b/src/cagpjax/policies/lanczos.py
@@ -17,28 +17,15 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
 
     Attributes:
         n_actions: Number of Lanczos vectors/actions to compute.
-        key: Random key for reproducible Lanczos iterations.
+        grad_rtol: Specifies the cutoff for similar eigenvalues, used to improve
+            gradient computation for (almost-)degenerate matrices.
+            If not provided, the default is 0.0.
+            If None or negative, all eigenvalues are treated as distinct.
+            (see [`cagpjax.linalg.eigh`][] for more details)
     """
 
+    n_actions: int = eqx.field(static=True)
     grad_rtol: float | None = eqx.field(static=True, default=0.0)
-
-    def __init__(
-        self,
-        n_actions: int,
-        grad_rtol: float | None = 0.0,
-    ):
-        """Initialize the Lanczos policy.
-
-        Args:
-            n_actions: Number of Lanczos vectors to compute.
-            grad_rtol: Specifies the cutoff for similar eigenvalues, used to improve
-                gradient computation for (almost-)degenerate matrices.
-                If not provided, the default is 0.0.
-                If None or negative, all eigenvalues are treated as distinct.
-                (see [`cagpjax.linalg.eigh`][] for more details)
-        """
-        super().__init__(n_actions)
-        self.grad_rtol = grad_rtol
 
     @override
     def to_actions(

--- a/src/cagpjax/policies/lanczos.py
+++ b/src/cagpjax/policies/lanczos.py
@@ -1,5 +1,6 @@
 """Lanczos-based policies."""
 
+import equinox as eqx
 from cola.ops import LinearOperator
 from jaxtyping import PRNGKeyArray
 from typing_extensions import override
@@ -19,7 +20,7 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
         key: Random key for reproducible Lanczos iterations.
     """
 
-    grad_rtol: float | None
+    grad_rtol: float | None = eqx.field(static=True, default=0.0)
 
     def __init__(
         self,

--- a/src/cagpjax/policies/lanczos.py
+++ b/src/cagpjax/policies/lanczos.py
@@ -24,7 +24,7 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
 
     def __init__(
         self,
-        n_actions: int | None,
+        n_actions: int,
         key: PRNGKeyArray | None = None,
         grad_rtol: float | None = 0.0,
     ):
@@ -39,14 +39,9 @@ class LanczosPolicy(AbstractBatchLinearSolverPolicy):
                 If None or negative, all eigenvalues are treated as distinct.
                 (see [`cagpjax.linalg.eigh`][] for more details)
         """
-        self._n_actions: int = n_actions
+        super().__init__(n_actions)
         self.key = key
         self.grad_rtol = grad_rtol
-
-    @property
-    @override
-    def n_actions(self) -> int:
-        return self._n_actions
 
     @override
     def to_actions(self, A: LinearOperator) -> LinearOperator:

--- a/src/cagpjax/policies/orthogonalization.py
+++ b/src/cagpjax/policies/orthogonalization.py
@@ -1,5 +1,6 @@
 import cola
 from cola.ops import LinearOperator
+from jaxtyping import PRNGKeyArray
 from typing_extensions import override
 
 from ..linalg import OrthogonalizationMethod, orthogonalize
@@ -36,8 +37,10 @@ class OrthogonalizationPolicy(AbstractBatchLinearSolverPolicy):
         self.n_reortho = n_reortho
 
     @override
-    def to_actions(self, A: LinearOperator) -> LinearOperator:
-        op = self.base_policy.to_actions(A)
+    def to_actions(
+        self, A: LinearOperator, *, key: PRNGKeyArray | None = None
+    ) -> LinearOperator:
+        op = self.base_policy.to_actions(A, key=key)
         return cola.lazify(
             orthogonalize(op, method=self.method, n_reortho=self.n_reortho)
         )

--- a/src/cagpjax/policies/orthogonalization.py
+++ b/src/cagpjax/policies/orthogonalization.py
@@ -30,14 +30,10 @@ class OrthogonalizationPolicy(AbstractBatchLinearSolverPolicy):
         method: OrthogonalizationMethod = OrthogonalizationMethod.QR,
         n_reortho: int = 0,
     ):
+        super().__init__(base_policy.n_actions)
         self.base_policy = base_policy
         self.method = method
         self.n_reortho = n_reortho
-
-    @property
-    @override
-    def n_actions(self):
-        return self.base_policy.n_actions
 
     @override
     def to_actions(self, A: LinearOperator) -> LinearOperator:

--- a/src/cagpjax/policies/orthogonalization.py
+++ b/src/cagpjax/policies/orthogonalization.py
@@ -28,16 +28,12 @@ class OrthogonalizationPolicy(AbstractBatchLinearSolverPolicy):
     )
     n_reortho: int = eqx.field(static=True, default=0)
 
-    def __init__(
-        self,
-        base_policy: AbstractBatchLinearSolverPolicy,
-        method: OrthogonalizationMethod = OrthogonalizationMethod.QR,
-        n_reortho: int = 0,
-    ):
-        super().__init__(base_policy.n_actions)
-        self.base_policy = base_policy
-        self.method = method
-        self.n_reortho = n_reortho
+    def __post_init__(self):
+        self.n_actions = self.base_policy.n_actions
+
+    def __check_init__(self):
+        if self.n_reortho < 0:
+            raise ValueError("n_reortho must be non-negative")
 
     @override
     def to_actions(

--- a/src/cagpjax/policies/orthogonalization.py
+++ b/src/cagpjax/policies/orthogonalization.py
@@ -1,4 +1,5 @@
 import cola
+import equinox as eqx
 from cola.ops import LinearOperator
 from jaxtyping import PRNGKeyArray
 from typing_extensions import override
@@ -22,8 +23,10 @@ class OrthogonalizationPolicy(AbstractBatchLinearSolverPolicy):
     """
 
     base_policy: AbstractBatchLinearSolverPolicy
-    method: OrthogonalizationMethod
-    n_reortho: int
+    method: OrthogonalizationMethod = eqx.field(
+        static=True, default=OrthogonalizationMethod.QR
+    )
+    n_reortho: int = eqx.field(static=True, default=0)
 
     def __init__(
         self,

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -3,8 +3,8 @@
 import cola
 import gpjax
 import jax.numpy as jnp
+import paramax
 from cola.ops import LinearOperator
-from gpjax.parameters import Parameter
 from jaxtyping import Array, Float
 
 from .base import AbstractBatchLinearSolverPolicy
@@ -18,8 +18,7 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
     inducing points and can be marked as trainable.
 
     Args:
-        pseudo_inputs: Pseudo-inputs for the kernel. If wrapped as a `gpjax.parameters.Parameter`,
-            they will be treated as trainable.
+        pseudo_inputs: Pseudo-inputs for the kernel.
         train_inputs: Training inputs or a dataset containing training inputs. These must be the
             same inputs in the same order as the training data used to condition the CaGP model.
         kernel: Kernel for the GP prior. It must be able to take `train_inputs` and `pseudo_inputs`
@@ -31,13 +30,15 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
         the actions using an [`OrthogonalizationPolicy`][cagpjax.policies.OrthogonalizationPolicy].
     """
 
-    pseudo_inputs: Float[Array, "M D"] | Parameter[Float[Array, "M D"]]
-    train_inputs: Float[Array, "N D"]
+    pseudo_inputs: (
+        Float[Array, "M D"] | paramax.AbstractUnwrappable[Float[Array, "M D"]]
+    )
+    train_inputs: paramax.AbstractUnwrappable[Float[Array, "N D"]]
     kernel: gpjax.kernels.AbstractKernel
 
     def __init__(
         self,
-        pseudo_inputs: Float[Array, "M D"] | Parameter[Float[Array, "M D"]],
+        pseudo_inputs: Float[Array, "M D"],
         train_inputs_or_dataset: Float[Array, "N D"] | gpjax.dataset.Dataset,
         kernel: gpjax.kernels.AbstractKernel,
     ):
@@ -50,9 +51,11 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
             train_inputs = train_inputs_or_dataset
         super().__init__(paramax.unwrap(pseudo_inputs).shape[0])
         self.pseudo_inputs = pseudo_inputs
-        self.train_inputs = jnp.atleast_2d(train_inputs)
+        self.train_inputs = paramax.non_trainable(jnp.atleast_2d(train_inputs))
         self.kernel = kernel
 
     def to_actions(self, A: LinearOperator) -> LinearOperator:
-        S = self.kernel.cross_covariance(self.train_inputs, self.pseudo_inputs[...])
+        S = self.kernel.cross_covariance(
+            paramax.unwrap(self.train_inputs), paramax.unwrap(self.pseudo_inputs)
+        )
         return cola.lazify(S)

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -4,7 +4,6 @@ import cola
 import gpjax
 import jax.numpy as jnp
 from cola.ops import LinearOperator
-from flax import nnx
 from gpjax.parameters import Parameter
 from jaxtyping import Array, Float
 

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -48,13 +48,10 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
             train_inputs = train_data.X
         else:
             train_inputs = train_inputs_or_dataset
+        super().__init__(paramax.unwrap(pseudo_inputs).shape[0])
         self.pseudo_inputs = pseudo_inputs
         self.train_inputs = jnp.atleast_2d(train_inputs)
         self.kernel = kernel
-
-    @property
-    def n_actions(self):
-        return self.pseudo_inputs.shape[0]
 
     def to_actions(self, A: LinearOperator) -> LinearOperator:
         S = self.kernel.cross_covariance(self.train_inputs, self.pseudo_inputs[...])

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -1,6 +1,7 @@
 """Pseodo-input linear solver policy."""
 
 import cola
+import equinox as eqx
 import gpjax
 import jax.numpy as jnp
 import paramax
@@ -38,10 +39,12 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
 
     def __init__(
         self,
-        pseudo_inputs: Float[Array, "M D"],
+        pseudo_inputs: Float[Array, "M D"]
+        | paramax.AbstractUnwrappable[Float[Array, "M D"]],
         train_inputs_or_dataset: Float[Array, "N D"] | gpjax.dataset.Dataset,
         kernel: gpjax.kernels.AbstractKernel,
     ):
+        self.pseudo_inputs = pseudo_inputs
         if isinstance(train_inputs_or_dataset, gpjax.dataset.Dataset):
             train_data = train_inputs_or_dataset
             if train_data.X is None:
@@ -49,10 +52,18 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
             train_inputs = train_data.X
         else:
             train_inputs = train_inputs_or_dataset
-        super().__init__(paramax.unwrap(pseudo_inputs).shape[0])
-        self.pseudo_inputs = pseudo_inputs
         self.train_inputs = paramax.non_trainable(jnp.atleast_2d(train_inputs))
         self.kernel = kernel
+        self.n_actions = paramax.unwrap(self.pseudo_inputs).shape[0]
+
+    def __check_init__(self):
+        if (
+            paramax.unwrap(self.train_inputs).shape[1:]
+            != paramax.unwrap(self.pseudo_inputs).shape[1:]
+        ):
+            raise ValueError(
+                "Training inputs and pseudo-inputs must have the same trailing dimensions."
+            )
 
     def to_actions(
         self, A: LinearOperator, *, key: PRNGKeyArray | None = None

--- a/src/cagpjax/policies/pseudoinput.py
+++ b/src/cagpjax/policies/pseudoinput.py
@@ -5,7 +5,7 @@ import gpjax
 import jax.numpy as jnp
 import paramax
 from cola.ops import LinearOperator
-from jaxtyping import Array, Float
+from jaxtyping import Array, Float, PRNGKeyArray
 
 from .base import AbstractBatchLinearSolverPolicy
 
@@ -54,7 +54,9 @@ class PseudoInputPolicy(AbstractBatchLinearSolverPolicy):
         self.train_inputs = paramax.non_trainable(jnp.atleast_2d(train_inputs))
         self.kernel = kernel
 
-    def to_actions(self, A: LinearOperator) -> LinearOperator:
+    def to_actions(
+        self, A: LinearOperator, *, key: PRNGKeyArray | None = None
+    ) -> LinearOperator:
         S = self.kernel.cross_covariance(
             paramax.unwrap(self.train_inputs), paramax.unwrap(self.pseudo_inputs)
         )

--- a/src/cagpjax/solvers/base.py
+++ b/src/cagpjax/solvers/base.py
@@ -2,8 +2,8 @@
 
 from abc import abstractmethod
 
+import equinox as eqx
 from cola.ops import LinearOperator
-from flax import nnx
 from jaxtyping import Array, Float
 from typing_extensions import Generic, TypeVar
 
@@ -12,7 +12,7 @@ from ..typing import ScalarFloat
 _LinearSolverState = TypeVar("_LinearSolverState")
 
 
-class AbstractLinearSolver(nnx.Module, Generic[_LinearSolverState]):
+class AbstractLinearSolver(eqx.Module, Generic[_LinearSolverState]):
     """
     Base class for linear solvers.
 

--- a/src/cagpjax/solvers/cholesky.py
+++ b/src/cagpjax/solvers/cholesky.py
@@ -1,6 +1,7 @@
 """Linear solvers based on Cholesky decomposition."""
 
 import cola
+import equinox as eqx
 import jax.numpy as jnp
 from cola.ops import LinearOperator
 from jaxtyping import Array, Float
@@ -26,7 +27,7 @@ class Cholesky(AbstractLinearSolver[CholeskyState]):
         jitter: Small amount of jitter to add to $A$ to ensure positive-definiteness.
     """
 
-    jitter: ScalarFloat | None
+    jitter: ScalarFloat | None = eqx.field(static=True, default=None)
 
     def __init__(self, jitter: ScalarFloat | None = None):
         self.jitter = jitter

--- a/src/cagpjax/solvers/cholesky.py
+++ b/src/cagpjax/solvers/cholesky.py
@@ -29,12 +29,13 @@ class Cholesky(AbstractLinearSolver[CholeskyState]):
 
     jitter: ScalarFloat | None = eqx.field(static=True, default=None)
 
-    def __init__(self, jitter: ScalarFloat | None = None):
-        self.jitter = jitter
+    def __check_init__(self):
+        if self.jitter is not None and self.jitter < 0:
+            raise ValueError("jitter must be non-negative")
 
     @override
     def init(self, A: LinearOperator) -> CholeskyState:
-        return lower_cholesky(A, self.jitter)
+        return lower_cholesky(A, jitter=self.jitter)
 
     @override
     def unwhiten(

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -46,8 +46,7 @@ class PseudoInverse(AbstractLinearSolver[PseudoInverseState]):
               of the operator (see [`jax.numpy.linalg.pinv`][]).
         grad_rtol: Specifies the cutoff for similar eigenvalues, used to improve
             gradient computation for (almost-)degenerate matrices.
-            If not provided, the default is 0.0.
-            If None or negative, all eigenvalues are treated as distinct.
+            If None (default), all eigenvalues are treated as distinct.
         alg: Algorithm for eigenvalue decomposition passed to [`cagpjax.linalg.eigh`][].
     """
 

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple
 
 import cola
+import equinox as eqx
 import jax
 from cola.ops import LinearOperator
 from jax import numpy as jnp
@@ -50,9 +51,9 @@ class PseudoInverse(AbstractLinearSolver[PseudoInverseState]):
         alg: Algorithm for eigenvalue decomposition passed to [`cagpjax.linalg.eigh`][].
     """
 
-    rtol: ScalarFloat | None
-    grad_rtol: float | None
-    alg: cola.linalg.Algorithm
+    rtol: ScalarFloat | None = eqx.field(static=True, default=None)
+    grad_rtol: float | None = eqx.field(static=True, default=None)
+    alg: cola.linalg.Algorithm = eqx.field(static=True, default=Eigh())
 
     def __init__(
         self,

--- a/src/cagpjax/solvers/pseudoinverse.py
+++ b/src/cagpjax/solvers/pseudoinverse.py
@@ -53,17 +53,13 @@ class PseudoInverse(AbstractLinearSolver[PseudoInverseState]):
 
     rtol: ScalarFloat | None = eqx.field(static=True, default=None)
     grad_rtol: float | None = eqx.field(static=True, default=None)
-    alg: cola.linalg.Algorithm = eqx.field(static=True, default=Eigh())
+    alg: cola.linalg.Algorithm = eqx.field(static=True, default_factory=Eigh)
 
-    def __init__(
-        self,
-        rtol: ScalarFloat | None = None,
-        grad_rtol: float | None = None,
-        alg: cola.linalg.Algorithm = Eigh(),
-    ):
-        self.rtol = rtol
-        self.grad_rtol = grad_rtol
-        self.alg = alg
+    def __check_init__(self):
+        if self.rtol is not None and self.rtol < 0:
+            raise ValueError("rtol must be non-negative")
+        if self.grad_rtol is not None and self.grad_rtol < 0:
+            raise ValueError("grad_rtol must be non-negative")
 
     @override
     def init(self, A: LinearOperator) -> PseudoInverseState:

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -5,6 +5,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 from gpjax.kernels import RBF
+from gpjax.kernels.computations import DenseKernelComputation
+from gpjax.parameters import Real
 
 from cagpjax.computations import LazyKernelComputation
 from cagpjax.operators import LazyKernel
@@ -35,8 +37,9 @@ class TestLazyKernelComputation:
     @pytest.fixture
     def kernel(self, dtype):
         return RBF(
-            lengthscale=jnp.array(1.0, dtype=dtype),
-            variance=jnp.array(1.0, dtype=dtype),
+            lengthscale=Real(jnp.array(1.0, dtype=dtype)),
+            variance=Real(jnp.array(1.0, dtype=dtype)),
+            compute_engine=DenseKernelComputation(),
         )
 
     @pytest.fixture(params=[(9, 5), (7, 10)], ids=["(9, 5)", "(7, 10)"])
@@ -89,7 +92,7 @@ class TestLazyKernelComputation:
         assert gram.batch_size_row == gram_lazy.batch_size_row
         assert gram.batch_size_col == gram_lazy.batch_size_col
 
-        assert jnp.allclose(cola.densify(gram), kernel.gram(x1).to_dense())
+        assert jnp.allclose(cola.densify(gram), kernel.gram(x1).as_matrix())
 
     @jax.default_matmul_precision("highest")
     def test_cross_covariance(

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -3,13 +3,14 @@
 import cola
 import jax
 import jax.numpy as jnp
+import lineax as lx
 import pytest
 from gpjax.kernels import RBF
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
 from cagpjax.computations import LazyKernelComputation
-from cagpjax.interop import lazify
+from cagpjax.interop import ColaLinearOperator, lazify
 from cagpjax.operators import LazyKernel
 
 jax.config.update("jax_enable_x64", True)
@@ -75,7 +76,9 @@ class TestLazyKernelComputation:
             batch_size=batch_size, max_memory_mb=max_memory_mb, checkpoint=checkpoint
         )
         x1, _ = inputs
-        gram = lazify(comp.gram(kernel, x1))
+        gram_raw = comp.gram(kernel, x1)
+        gram = lazify(gram_raw)
+        assert isinstance(gram_raw, (ColaLinearOperator, lx.TaggedLinearOperator))
         assert isinstance(gram, LazyKernel)
         assert gram.shape == (x1.shape[0], x1.shape[0])
         assert gram.dtype == dtype
@@ -103,7 +106,9 @@ class TestLazyKernelComputation:
             batch_size=batch_size, max_memory_mb=max_memory_mb, checkpoint=checkpoint
         )
         x1, x2 = inputs
-        cross_cov = comp.cross_covariance(kernel, x1, x2)
+        cross_cov_raw = comp.cross_covariance(kernel, x1, x2)
+        cross_cov = lazify(cross_cov_raw)
+        assert isinstance(cross_cov_raw, ColaLinearOperator)
         assert isinstance(cross_cov, LazyKernel)
         assert cross_cov.shape == (x1.shape[0], x2.shape[0])
         assert cross_cov.dtype == dtype

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -78,10 +78,11 @@ class TestLazyKernelComputation:
         x1, _ = inputs
         gram_raw = comp.gram(kernel, x1)
         gram = lazify(gram_raw)
+        expected_dtype = kernel(x1[0], x1[0]).dtype
         assert isinstance(gram_raw, (ColaLinearOperator, lx.TaggedLinearOperator))
         assert isinstance(gram, LazyKernel)
         assert gram.shape == (x1.shape[0], x1.shape[0])
-        assert gram.dtype == dtype
+        assert gram.dtype == expected_dtype
         assert gram.checkpoint == checkpoint
         assert gram.isa(cola.PSD)
 
@@ -106,12 +107,13 @@ class TestLazyKernelComputation:
             batch_size=batch_size, max_memory_mb=max_memory_mb, checkpoint=checkpoint
         )
         x1, x2 = inputs
+        expected_dtype = kernel.cross_covariance(x1, x2).dtype
         cross_cov_raw = comp.cross_covariance(kernel, x1, x2)
         cross_cov = lazify(cross_cov_raw)
         assert isinstance(cross_cov_raw, ColaLinearOperator)
         assert isinstance(cross_cov, LazyKernel)
         assert cross_cov.shape == (x1.shape[0], x2.shape[0])
-        assert cross_cov.dtype == dtype
+        assert cross_cov.dtype == expected_dtype
         assert cross_cov.checkpoint == checkpoint
 
         cross_cov_lazy = LazyKernel(

--- a/tests/test_computations.py
+++ b/tests/test_computations.py
@@ -9,8 +9,8 @@ from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
 from cagpjax.computations import LazyKernelComputation
+from cagpjax.interop import lazify
 from cagpjax.operators import LazyKernel
-from cagpjax.operators.utils import lazify
 
 jax.config.update("jax_enable_x64", True)
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -10,7 +10,7 @@ from numpyro.distributions import MultivariateNormal
 
 import cagpjax
 from cagpjax.distributions import GaussianDistribution
-from cagpjax.operators.utils import lazify
+from cagpjax.interop import lazify
 from cagpjax.solvers import Cholesky, PseudoInverse
 
 jax.config.update("jax_enable_x64", True)

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -1,0 +1,107 @@
+"""Tests for interop utility functions."""
+
+import cola
+import jax
+import jax.numpy as jnp
+import lineax as lx
+import numpy as np
+import pytest
+
+from cagpjax import interop
+from cagpjax.interop import ColaLinearOperator
+
+jax.config.update("jax_enable_x64", True)
+
+class TestInteropUtils:
+    @pytest.fixture(params=[jnp.float32, jnp.float64])
+    def dtype(self, request):
+        return request.param
+
+    @pytest.fixture(params=[4, 9])
+    def n(self, request):
+        return request.param
+
+    def test_lazify_unwraps_cola_lineax_operator(self, n, dtype, key=jax.random.key(0)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        cola_op = cola.lazify(matrix)
+        wrapped = ColaLinearOperator(cola_op)
+        recovered = interop.lazify(wrapped)
+        assert recovered is cola_op
+
+    def test_lazify_preserves_psd_tag(self, n, dtype, key=jax.random.key(1)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        psd_cola = cola.PSD(cola.lazify(matrix @ matrix.T))
+        wrapped = lx.TaggedLinearOperator(
+            ColaLinearOperator(psd_cola), lx.positive_semidefinite_tag
+        )
+        recovered = interop.lazify(wrapped)
+        assert recovered.isa(cola.PSD)
+        np.testing.assert_allclose(cola.densify(recovered), cola.densify(psd_cola))
+
+    def test_lazify_tagged_non_psd_operator(self, n, dtype, key=jax.random.key(11)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        cola_op = cola.lazify(matrix)
+        tagged = lx.TaggedLinearOperator(ColaLinearOperator(cola_op), lx.symmetric_tag)
+        recovered = interop.lazify(tagged)
+        assert not recovered.isa(cola.PSD)
+        np.testing.assert_allclose(cola.densify(recovered), matrix)
+
+    def test_lazify_existing_cola_operator_passthrough(
+        self, n, dtype, key=jax.random.key(12)
+    ):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        cola_op = cola.lazify(matrix)
+        recovered = interop.lazify(cola_op)
+        assert recovered is cola_op
+
+    def test_lazify_lineax_matrix_operator(self, n, dtype, key=jax.random.key(13)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        op = lx.MatrixLinearOperator(matrix)
+        recovered = interop.lazify(op)
+        np.testing.assert_allclose(cola.densify(recovered), matrix)
+
+    def test_lazify_generic_lineax_operator(self, n, dtype, key=jax.random.key(14)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        op = lx.AddLinearOperator(lx.MatrixLinearOperator(matrix), lx.DiagonalLinearOperator(jnp.ones(n, dtype=dtype)))
+        recovered = interop.lazify(op)
+        np.testing.assert_allclose(cola.densify(recovered), op.as_matrix())
+
+    def test_lazify_raw_array_fallback(self, n, dtype, key=jax.random.key(15)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        recovered = interop.lazify(matrix)
+        np.testing.assert_allclose(cola.densify(recovered), matrix)
+
+    def test_to_lineax_roundtrip_dense(self, n, dtype, key=jax.random.key(2)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        cola_op = cola.lazify(matrix)
+        lineax_op = interop.to_lineax(cola_op)
+        back_to_cola = interop.lazify(lineax_op)
+        np.testing.assert_allclose(cola.densify(back_to_cola), matrix)
+        assert isinstance(lineax_op, ColaLinearOperator)
+
+    def test_to_lineax_diagonal_and_identity(self, n, dtype, key=jax.random.key(3)):
+        diag = jax.random.normal(key, (n,), dtype=dtype)
+        diag_op = cola.ops.Diagonal(diag)
+        id_op = cola.ops.Identity((n, n), dtype)
+
+        lineax_diag = interop.to_lineax(diag_op)
+        lineax_id = interop.to_lineax(id_op)
+
+        assert isinstance(lineax_diag, lx.DiagonalLinearOperator)
+        assert isinstance(lineax_id, lx.IdentityLinearOperator)
+        np.testing.assert_allclose(interop.lazify(lineax_diag).to_dense(), jnp.diag(diag))
+        np.testing.assert_allclose(interop.lazify(lineax_id).to_dense(), jnp.eye(n))
+
+    def test_to_lineax_passthrough_existing_lineax_operator(
+        self, n, dtype, key=jax.random.key(16)
+    ):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        op = lx.MatrixLinearOperator(matrix)
+        converted = interop.to_lineax(op)
+        assert converted is op
+
+    def test_to_lineax_raw_array_fallback(self, n, dtype, key=jax.random.key(17)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        converted = interop.to_lineax(matrix)
+        assert isinstance(converted, lx.MatrixLinearOperator)
+        np.testing.assert_allclose(converted.as_matrix(), matrix)

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -12,6 +12,7 @@ from cagpjax.interop import ColaLinearOperator
 
 jax.config.update("jax_enable_x64", True)
 
+
 class TestInteropUtils:
     @pytest.fixture(params=[jnp.float32, jnp.float64])
     def dtype(self, request):
@@ -62,7 +63,10 @@ class TestInteropUtils:
 
     def test_lazify_generic_lineax_operator(self, n, dtype, key=jax.random.key(14)):
         matrix = jax.random.normal(key, (n, n), dtype=dtype)
-        op = lx.AddLinearOperator(lx.MatrixLinearOperator(matrix), lx.DiagonalLinearOperator(jnp.ones(n, dtype=dtype)))
+        op = lx.AddLinearOperator(
+            lx.MatrixLinearOperator(matrix),
+            lx.DiagonalLinearOperator(jnp.ones(n, dtype=dtype)),
+        )
         recovered = interop.lazify(op)
         np.testing.assert_allclose(cola.densify(recovered), op.as_matrix())
 
@@ -89,7 +93,9 @@ class TestInteropUtils:
 
         assert isinstance(lineax_diag, lx.DiagonalLinearOperator)
         assert isinstance(lineax_id, lx.IdentityLinearOperator)
-        np.testing.assert_allclose(interop.lazify(lineax_diag).to_dense(), jnp.diag(diag))
+        np.testing.assert_allclose(
+            interop.lazify(lineax_diag).to_dense(), jnp.diag(diag)
+        )
         np.testing.assert_allclose(interop.lazify(lineax_id).to_dense(), jnp.eye(n))
 
     def test_to_lineax_passthrough_existing_lineax_operator(

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -75,6 +75,14 @@ class TestInteropUtils:
         recovered = interop.lazify(matrix)
         np.testing.assert_allclose(cola.densify(recovered), matrix)
 
+    def test_cola_linear_operator_interface(self, n, dtype, key=jax.random.key(18)):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        wrapped = ColaLinearOperator(cola.lazify(matrix))
+        vector = jax.random.normal(key, (n,), dtype=dtype)
+        np.testing.assert_allclose(wrapped.mv(vector), matrix @ vector)
+        np.testing.assert_allclose(wrapped.as_matrix(), matrix)
+        np.testing.assert_allclose(wrapped.transpose().as_matrix(), matrix.T)
+
     def test_to_lineax_roundtrip_dense(self, n, dtype, key=jax.random.key(2)):
         matrix = jax.random.normal(key, (n, n), dtype=dtype)
         cola_op = cola.lazify(matrix)
@@ -111,3 +119,12 @@ class TestInteropUtils:
         converted = interop.to_lineax(matrix)
         assert isinstance(converted, lx.MatrixLinearOperator)
         np.testing.assert_allclose(converted.as_matrix(), matrix)
+
+    def test_lineax_psd_predicate_for_cola_wrapper(
+        self, n, dtype, key=jax.random.key(19)
+    ):
+        matrix = jax.random.normal(key, (n, n), dtype=dtype)
+        wrapped_psd = ColaLinearOperator(cola.PSD(cola.lazify(matrix @ matrix.T)))
+        wrapped_non_psd = ColaLinearOperator(cola.lazify(matrix))
+        assert lx.is_positive_semidefinite(wrapped_psd)
+        assert not lx.is_positive_semidefinite(wrapped_non_psd)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -211,7 +211,7 @@ class TestEigh:
         )
 
     @pytest.mark.parametrize("alg_class", [Eigh, Lanczos])
-    @pytest.mark.parametrize("grad_rtol", [None, -1.0, 0.0])
+    @pytest.mark.parametrize("grad_rtol", [None, 0.0])
     def test_eigh_gradient_degenerate(self, alg_class, grad_rtol, dtype):
         """Test gradient computation with degenerate eigenvalues."""
         n = 4

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -266,6 +266,12 @@ class TestEigh:
         else:
             assert jnp.allclose(grad, 0.0, atol=1e-9)
 
+    def test_eigh_errors_on_negative_grad_rtol(self):
+        """Test that eigh rejects negative grad_rtol values."""
+        A = cola.ops.Dense(jnp.eye(3, dtype=jnp.float64))
+        with pytest.raises(ValueError, match="grad_rtol must be None or non-negative"):
+            eigh(A, grad_rtol=-1.0)
+
 
 class TestLowerCholesky:
     """Tests for ``lower_cholesky``."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 """Tests for Gaussian process models."""
 
+import equinox as eqx
 import gpjax as gpjax
 import jax
 import jax.numpy as jnp
@@ -103,7 +104,8 @@ class TestComputationAwareGP:
 
     def make_posterior(self, n_train, dtype, compute_engine, constant_type):
         kernel = RBF(
-            variance=jnp.array(1.0, dtype=dtype),
+            lengthscale=Real(jnp.array(1.0, dtype=dtype)),
+            variance=Real(jnp.array(1.0, dtype=dtype)),
             compute_engine=compute_engine,
         )
         likelihood = Gaussian(
@@ -226,7 +228,9 @@ class TestComputationAwareGP:
         assert pred.scale.shape[0] == pred_exact.scale.out_size()
         assert pred.scale.shape[1] == pred_exact.scale.in_size()
         assert jnp.allclose(pred.mean, pred_exact.mean, atol=1e-4)
-        assert jnp.allclose(pred.scale.to_dense(), pred_exact.scale.as_matrix(), atol=1e-5)
+        assert jnp.allclose(
+            pred.scale.to_dense(), pred_exact.scale.as_matrix(), atol=1e-5
+        )
 
     def test_prior_kl_consistency(self, cagp, cagp_state, train_data, dtype):
         """Test that custom ``prior_kl`` matches KL computed from result of ``predict``."""
@@ -235,7 +239,6 @@ class TestComputationAwareGP:
 
         kl = cagp.prior_kl(cagp_state)
         assert isinstance(kl, jnp.ndarray)
-        assert kl.dtype == dtype
         assert jnp.isscalar(kl)
         assert jnp.isfinite(kl)
         assert kl >= 0.0
@@ -267,14 +270,16 @@ class TestComputationAwareGP:
             pytest.skip("Skipping float32 test due to numerical precision limitations")
 
         nz_values = jax.random.normal(key, (n_train,), dtype=dtype)
+        policy = BlockSparsePolicy(n_actions=n_train, nz_values=nz_values)
+        cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
+        params, static = eqx.partition(cagp, eqx.is_array)
 
-        def kl_objective(raw_nz_values):
-            policy = BlockSparsePolicy(n_actions=n_train, nz_values=raw_nz_values)
-            cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
-            cagp_state = cagp.init(train_data)
-            return cagp.prior_kl(cagp_state)
+        def kl_objective(params):
+            model = eqx.combine(params, static)
+            cagp_state = model.init(train_data)
+            return model.prior_kl(cagp_state)
 
-        jax.test_util.check_grads(kl_objective, (nz_values,), order=1, modes=["rev"])
+        jax.test_util.check_grads(kl_objective, (params,), order=1, modes=["rev"])
 
     def test_integration_elbo(self, cagp, cagp_state, posterior, train_data, dtype):
         """Test that ``elbo`` objective from GPJax is computed correctly."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,14 +272,12 @@ class TestComputationAwareGP:
         nz_values = jax.random.normal(key, (n_train,), dtype=dtype)
         policy = BlockSparsePolicy(n_actions=n_train, nz_values=nz_values)
         cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
-        params, static = eqx.partition(cagp, eqx.is_array)
 
-        def kl_objective(params):
-            model = eqx.combine(params, static)
+        def kl_objective(model):
             cagp_state = model.init(train_data)
             return model.prior_kl(cagp_state)
 
-        jax.test_util.check_grads(kl_objective, (params,), order=1, modes=["rev"])
+        jax.test_util.check_grads(kl_objective, (cagp,), order=1, modes=["rev"])
 
     def test_integration_elbo(self, cagp, cagp_state, posterior, train_data, dtype):
         """Test that ``elbo`` objective from GPJax is computed correctly."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -49,7 +49,9 @@ class TestComputationAwareGP:
         if policy_class is LanczosPolicy:
             return policy_class(n_actions=n_actions)
         elif policy_class is BlockSparsePolicy:
-            return policy_class(n_actions=n_actions, n=n_train, key=key, dtype=dtype)
+            return policy_class.from_random(
+                key=key, num_datapoints=n_train, n_actions=n_actions, dtype=dtype
+            )
         else:
             raise ValueError(f"Invalid policy class: {policy_class}")
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,6 @@ import jax
 import jax.numpy as jnp
 import jax.test_util
 import pytest
-from flax import nnx
 from gpjax.gps import ConjugatePosterior
 from gpjax.kernels import RBF
 from gpjax.kernels.computations import DenseKernelComputation
@@ -229,7 +228,6 @@ class TestComputationAwareGP:
             pred.scale.to_dense(), pred_exact.scale.to_dense(), atol=1e-5
         )
 
-    @pytest.mark.skipif(constant_type is nnx.Variable, reason="Test is redundant")
     def test_prior_kl_consistency(self, cagp, cagp_state, train_data, dtype):
         """Test that custom ``prior_kl`` matches KL computed from result of ``predict``."""
         if dtype == jnp.float32:
@@ -255,7 +253,6 @@ class TestComputationAwareGP:
 
         assert jnp.allclose(kl, kl_explicit, rtol=1e-4)
 
-    @pytest.mark.skipif(constant_type is nnx.Variable, reason="Test is redundant")
     def test_prior_kl_gradient_sparse_actions(
         self,
         posterior,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,7 +47,7 @@ class TestComputationAwareGP:
     def policy(self, request, n_train, n_actions, dtype, key=jax.random.key(98)):
         policy_class = request.param
         if policy_class is LanczosPolicy:
-            return policy_class(n_actions=n_actions, key=key)
+            return policy_class(n_actions=n_actions)
         elif policy_class is BlockSparsePolicy:
             return policy_class(n_actions=n_actions, n=n_train, key=key, dtype=dtype)
         else:
@@ -138,7 +138,7 @@ class TestComputationAwareGP:
     @pytest.fixture
     def cagp_state(self, cagp, train_data):
         """Create CAGP state."""
-        return cagp.init(train_data)
+        return cagp.init(train_data, key=jax.random.key(0))
 
     @pytest.mark.skipif(constant_type is Real, reason="Test is redundant")
     def test_initialization(self, policy, posterior, solver):
@@ -161,7 +161,7 @@ class TestComputationAwareGP:
             "error", message=".*scatter inputs have incompatible types.*"
         )
 
-        state = cagp.init(train_data)
+        state = cagp.init(train_data, key=jax.random.key(0))
         assert isinstance(state, cagpjax.models.cagp.ComputationAwareGPState)
 
     @pytest.mark.parametrize(
@@ -217,9 +217,9 @@ class TestComputationAwareGP:
             pytest.skip("Skipping float32 test due to numerical precision limitations")
 
         x_test = test_data.X
-        policy = LanczosPolicy(n_actions=n_train, key=key)
+        policy = LanczosPolicy(n_actions=n_train)
         cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
-        cagp_state = cagp.init(train_data)
+        cagp_state = cagp.init(train_data, key=key)
         pred = cagp.predict(cagp_state, x_test)
 
         pred_exact = posterior_eager.predict(x_test, train_data)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -186,9 +186,9 @@ class TestComputationAwareGP:
         expected_dtype = cagp_state.repr_weights_proj.dtype
         assert isinstance(pred, GaussianDistribution)
         assert pred.mean.shape == (n_test,)
-        assert pred.mean.dtype == dtype
+        assert pred.mean.dtype == expected_dtype
         assert pred.scale.shape == (n_test, n_test)
-        assert pred.scale.dtype == dtype
+        assert pred.scale.dtype == expected_dtype
 
     def test_predict_no_inputs(self, cagp, cagp_state, train_data, dtype):
         """Test that CAGP predict method with no inputs evaluates at training inputs."""
@@ -287,8 +287,9 @@ class TestComputationAwareGP:
             pytest.skip("Skipping float32 test due to numerical precision limitations")
 
         elbo_value = cagp.elbo(cagp_state)
+        expected_dtype = cagp_state.repr_weights_proj.dtype
         assert isinstance(elbo_value, jnp.ndarray)
-        assert elbo_value.dtype == dtype
+        assert elbo_value.dtype == expected_dtype
         assert jnp.isscalar(elbo_value)
         assert jnp.isfinite(elbo_value)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,7 +138,7 @@ class TestComputationAwareGP:
         """Create CAGP state."""
         return cagp.init(train_data)
 
-    @pytest.mark.skipif(constant_type is nnx.Variable, reason="Test is redundant")
+    @pytest.mark.skipif(constant_type is Real, reason="Test is redundant")
     def test_initialization(self, policy, posterior, solver):
         """Test that CAGP initializes correctly."""
         cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
@@ -267,21 +267,14 @@ class TestComputationAwareGP:
             pytest.skip("Skipping float32 test due to numerical precision limitations")
 
         nz_values = jax.random.normal(key, (n_train,), dtype=dtype)
-        policy = BlockSparsePolicy(n_actions=n_train, nz_values=Real(nz_values))
 
-        # use nnx's utlities to split the policy into a graph definition and parameters
-        # this allows us to bypass gpjax.parameters.Parameter's check that the parameter is an
-        # ArrayLike (on jax > v0.8.1, GradTracer is not an ArrayLike) and mirrors how gpjax.fit
-        # computes gradients wrt parameters.
-        graphdef, params = nnx.split(policy, Real)
-
-        def kl_objective(params: nnx.State):
-            policy = nnx.merge(graphdef, params)
+        def kl_objective(raw_nz_values):
+            policy = BlockSparsePolicy(n_actions=n_train, nz_values=raw_nz_values)
             cagp = ComputationAwareGP(posterior=posterior, policy=policy, solver=solver)
             cagp_state = cagp.init(train_data)
             return cagp.prior_kl(cagp_state)
 
-        jax.test_util.check_grads(kl_objective, (params,), order=1, modes=["rev"])
+        jax.test_util.check_grads(kl_objective, (nz_values,), order=1, modes=["rev"])
 
     def test_integration_elbo(self, cagp, cagp_state, posterior, train_data, dtype):
         """Test that ``elbo`` objective from GPJax is computed correctly."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import gpjax as gpjax
 import jax
 import jax.numpy as jnp
 import jax.test_util
+import lineax
 import pytest
 from gpjax.gps import ConjugatePosterior
 from gpjax.kernels import RBF
@@ -102,7 +103,6 @@ class TestComputationAwareGP:
 
     def make_posterior(self, n_train, dtype, compute_engine, constant_type):
         kernel = RBF(
-            lengthscale=jnp.array(1.0, dtype=dtype),
             variance=jnp.array(1.0, dtype=dtype),
             compute_engine=compute_engine,
         )
@@ -179,6 +179,7 @@ class TestComputationAwareGP:
         """Test that CAGP predict method with test inputs works."""
         x_test = test_data.X
         pred = cagp.predict(cagp_state, x_test)
+        expected_dtype = cagp_state.repr_weights_proj.dtype
         assert isinstance(pred, GaussianDistribution)
         assert pred.mean.shape == (n_test,)
         assert pred.mean.dtype == dtype
@@ -222,11 +223,10 @@ class TestComputationAwareGP:
         pred_exact = posterior_eager.predict(x_test, train_data)
 
         assert pred.mean.shape == pred_exact.mean.shape
-        assert pred.scale.shape == pred_exact.scale.shape
+        assert pred.scale.shape[0] == pred_exact.scale.out_size()
+        assert pred.scale.shape[1] == pred_exact.scale.in_size()
         assert jnp.allclose(pred.mean, pred_exact.mean, atol=1e-4)
-        assert jnp.allclose(
-            pred.scale.to_dense(), pred_exact.scale.to_dense(), atol=1e-5
-        )
+        assert jnp.allclose(pred.scale.to_dense(), pred_exact.scale.as_matrix(), atol=1e-5)
 
     def test_prior_kl_consistency(self, cagp, cagp_state, train_data, dtype):
         """Test that custom ``prior_kl`` matches KL computed from result of ``predict``."""
@@ -246,7 +246,7 @@ class TestComputationAwareGP:
         p = cagp.posterior.prior.predict(train_data.X)
         kl_explicit = gpjax.distributions.GaussianDistribution(
             q.mean,
-            gpjax.linalg.operators.Dense(
+            lineax.MatrixLinearOperator(
                 q.scale.to_dense() + jnp.eye(q.scale.shape[0]) * jitter
             ),
         ).kl_divergence(p)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -243,7 +243,7 @@ class TestLazyKernel:
             checkpoint=checkpoint,
         )
         x1, x2 = inputs
-        assert op.dtype == x1.dtype
+        assert op.dtype == kernel(x1[0], x2[0]).dtype
         assert op.kernel is kernel
         assert op.x1 is x1
         assert op.x2 is x2

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -12,11 +12,11 @@ from gpjax.kernels import RBF
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
+from cagpjax.interop import lazify
 from cagpjax.operators import BlockDiagonalSparse
 from cagpjax.operators.annotations import ScaledOrthogonal
 from cagpjax.operators.diag_like import diag_like
 from cagpjax.operators.lazy_kernel import LazyKernel
-from cagpjax.interop import lazify
 
 jax.config.update("jax_enable_x64", True)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -293,6 +293,7 @@ class TestLazyKernel:
         lengthscale, variance = jax.random.uniform(subkeys[3], (2,), dtype=dtype)
 
         kernel = RBF(
+            lengthscale=lengthscale,
             variance=variance,
             compute_engine=DenseKernelComputation(),
         )
@@ -304,7 +305,7 @@ class TestLazyKernel:
             with jax.default_matmul_precision("highest"):
                 return jnp.vdot(v, op @ v)
 
-        assert jnp.isfinite(loss(params))
+        assert jnp.isfinite(loss(kernel))
         if grad:
             rtol = 1e-2 if dtype == jnp.float32 else 1e-6
             jax.test_util.check_grads(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -8,7 +8,6 @@ import jax.test_util
 import numpy as np
 import pytest
 from cola.ops import Dense, Diagonal, LinearOperator, ScalarMul
-from flax import nnx
 from gpjax.kernels import RBF
 
 from cagpjax.operators import BlockDiagonalSparse

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -16,7 +16,7 @@ from cagpjax.operators import BlockDiagonalSparse
 from cagpjax.operators.annotations import ScaledOrthogonal
 from cagpjax.operators.diag_like import diag_like
 from cagpjax.operators.lazy_kernel import LazyKernel
-from cagpjax.operators.utils import lazify
+from cagpjax.interop import lazify
 
 jax.config.update("jax_enable_x64", True)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -309,6 +309,5 @@ class TestLazyKernel:
         if grad:
             rtol = 1e-2 if dtype == jnp.float32 else 1e-6
             jax.test_util.check_grads(
-                loss, (params,), order=1, modes=["rev"], rtol=rtol
                 loss, (kernel,), order=1, modes=["rev"], rtol=rtol
             )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,6 @@
 """Tests for custom linear operators."""
 
 import cola
-import gpjax
 import jax
 import jax.numpy as jnp
 import jax.test_util
@@ -292,11 +291,13 @@ class TestLazyKernel:
         v = jax.random.normal(subkeys[2], (n,), dtype=dtype)
 
         lengthscale, variance = jax.random.uniform(subkeys[3], (2,), dtype=dtype)
-        kernel = RBF(lengthscale=lengthscale, variance=variance)
-        graphdef, params = nnx.split(kernel, gpjax.parameters.Parameter)
 
-        def loss(params):
-            kernel = nnx.merge(graphdef, params)
+        kernel = RBF(
+            variance=variance,
+            compute_engine=DenseKernelComputation(),
+        )
+
+        def loss(kernel):
             op = LazyKernel(
                 kernel, x1, x2, max_memory_mb=max_memory_mb, checkpoint=checkpoint
             )
@@ -308,4 +309,5 @@ class TestLazyKernel:
             rtol = 1e-2 if dtype == jnp.float32 else 1e-6
             jax.test_util.check_grads(
                 loss, (params,), order=1, modes=["rev"], rtol=rtol
+                loss, (kernel,), order=1, modes=["rev"], rtol=rtol
             )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -5,10 +5,13 @@ import gpjax
 import jax
 import jax.numpy as jnp
 import jax.test_util
+import lineax as lx
 import numpy as np
 import pytest
 from cola.ops import Dense, Diagonal, LinearOperator, ScalarMul
 from gpjax.kernels import RBF
+from gpjax.kernels.computations import DenseKernelComputation
+from gpjax.parameters import Real
 
 from cagpjax.operators import BlockDiagonalSparse
 from cagpjax.operators.annotations import ScaledOrthogonal
@@ -85,49 +88,31 @@ class TestUtils:
         lazy_op = lazify(op)
         assert lazy_op is op
 
-    try:  # test support for GPJax v0.12.0
-        import gpjax.linalg
+    def test_lazify_lineax_matrix(self, nrows, ncols, dtype, key=jax.random.key(42)):
+        matrix = jax.random.normal(key, (nrows, ncols), dtype=dtype)
+        op = lx.MatrixLinearOperator(matrix)
+        lazy_op = lazify(op)
+        assert isinstance(lazy_op, cola.ops.Dense)
+        assert lazy_op.shape == (nrows, ncols)
+        assert lazy_op.dtype == dtype
+        np.testing.assert_allclose(lazy_op.to_dense(), matrix)
 
-        def test_lazify_gpjax_dense(self, nrows, ncols, dtype, key=jax.random.key(42)):
-            op = gpjax.linalg.Dense(jax.random.normal(key, (nrows, ncols), dtype=dtype))
-            lazy_op = lazify(op)
-            assert isinstance(lazy_op, cola.ops.Dense)
-            assert lazy_op.shape == (nrows, ncols)
-            assert lazy_op.dtype == dtype
-            np.testing.assert_allclose(lazy_op.to_dense(), op.to_dense())
+    def test_lazify_lineax_diagonal(self, nrows, dtype, key=jax.random.key(42)):
+        diag = jax.random.normal(key, (nrows,), dtype=dtype)
+        op = lx.DiagonalLinearOperator(diag)
+        lazy_op = lazify(op)
+        assert isinstance(lazy_op, cola.ops.Diagonal)
+        assert lazy_op.shape == (nrows, nrows)
+        assert lazy_op.dtype == dtype
+        np.testing.assert_allclose(lazy_op.to_dense(), jnp.diag(diag))
 
-        def test_lazify_gpjax_diagonal(self, nrows, dtype, key=jax.random.key(42)):
-            diag = jax.random.normal(key, (nrows,), dtype=dtype)
-            op = gpjax.linalg.Diagonal(diag)
-            lazy_op = lazify(op)
-            assert isinstance(lazy_op, cola.ops.Diagonal)
-            assert lazy_op.shape == (nrows, nrows)
-            assert lazy_op.dtype == dtype
-            np.testing.assert_allclose(lazy_op.to_dense(), jnp.diag(diag))
-
-        def test_lazify_gpjax_identity(self, nrows, dtype, key=jax.random.key(42)):
-            op = gpjax.linalg.Identity(nrows, dtype=dtype)
-            lazy_op = lazify(op)
-            assert isinstance(lazy_op, cola.ops.Identity)
-            assert lazy_op.shape == (nrows, nrows)
-            assert lazy_op.dtype == dtype
-
-        @pytest.mark.parametrize("lower", [True, False])
-        def test_lazify_gpjax_triangular(
-            self, nrows, dtype, lower, key=jax.random.key(42)
-        ):
-            op = gpjax.linalg.Triangular(
-                jax.random.normal(key, (nrows, nrows), dtype=dtype), lower=lower
-            )
-            lazy_op = lazify(op)
-            assert isinstance(lazy_op, cola.ops.Triangular)
-            assert lazy_op.shape == (nrows, nrows)
-            assert lazy_op.dtype == dtype
-            assert lazy_op.lower == lower
-            np.testing.assert_allclose(lazy_op.to_dense(), op.to_dense())
-
-    except ImportError:
-        pass
+    def test_lazify_lineax_identity(self, nrows, dtype):
+        metadata = jax.ShapeDtypeStruct((nrows,), dtype)
+        op = lx.IdentityLinearOperator(metadata)
+        lazy_op = lazify(op)
+        assert isinstance(lazy_op, cola.ops.Identity)
+        assert lazy_op.shape == (nrows, nrows)
+        assert lazy_op.dtype == dtype
 
 
 class TestBlockDiagonalSparse:
@@ -226,8 +211,9 @@ class TestLazyKernel:
     def kernel(self, dtype):
         """Create RBF kernel for testing."""
         return RBF(
-            lengthscale=jnp.array(1.0, dtype=dtype),
-            variance=jnp.array(1.0, dtype=dtype),
+            lengthscale=Real(jnp.array(1.0, dtype=dtype)),
+            variance=Real(jnp.array(1.0, dtype=dtype)),
+            compute_engine=DenseKernelComputation(),
         )
 
     @pytest.fixture

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -60,6 +60,11 @@ class TestLanczosPolicy:
         actions = LanczosPolicy(n_actions=n_actions)
         assert actions.n_actions == n_actions
 
+    def test_init_errors_on_nonpositive_actions(self):
+        """Test n_actions validation from base policy."""
+        with pytest.raises(ValueError, match="n_actions must be at least 1"):
+            LanczosPolicy(n_actions=0)
+
     @pytest.mark.parametrize("key", [jax.random.key(42)])
     def test_actions_consistency(self, psd_linear_operator, key):
         """Test that the actions are consistent."""
@@ -166,6 +171,16 @@ class TestBlockSparsePolicy:
         assert policy.n_actions == n_actions
         assert paramax.unwrap(policy.nz_values).shape == (n,)
         assert paramax.unwrap(policy.nz_values).dtype == dtype
+
+    @pytest.mark.parametrize("n_actions", [1, 3])
+    def test_from_random_errors_on_zero_datapoints(self, n_actions):
+        """Test validation for num_datapoints."""
+        with pytest.raises(ValueError, match="num_datapoints must be at least 1"):
+            BlockSparsePolicy.from_random(
+                key=jax.random.key(123),
+                num_datapoints=0,
+                n_actions=n_actions,
+            )
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
@@ -334,6 +349,39 @@ class TestPseudoInputPolicy:
         op = lazify(kernel.gram(train_inputs))
         _test_batch_policy_actions_consistency(policy, op)
 
+    def test_errors_when_dataset_has_no_inputs(self):
+        """Test dataset input validation."""
+        kernel = gpjax.kernels.RBF(
+            lengthscale=Real(jnp.ones(1)),
+            variance=Real(jnp.array(1.0)),
+            compute_engine=DenseKernelComputation(),
+        )
+        with pytest.raises(ValueError, match="Dataset must contain training inputs"):
+            PseudoInputPolicy(
+                pseudo_inputs=jnp.zeros((2, 1)),
+                train_inputs_or_dataset=Dataset(X=None, y=jnp.zeros((2, 1))),
+                kernel=kernel,
+            )
+
+    def test_errors_on_shape_mismatch(self):
+        """Test pseudo-input and training-input shape validation."""
+        kernel = gpjax.kernels.RBF(
+            lengthscale=Real(jnp.ones(1)),
+            variance=Real(jnp.array(1.0)),
+            compute_engine=DenseKernelComputation(),
+        )
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Training inputs and pseudo-inputs must have the same trailing dimensions"
+            ),
+        ):
+            PseudoInputPolicy(
+                pseudo_inputs=jnp.zeros((3, 2)),
+                train_inputs_or_dataset=jnp.zeros((5, 1)),
+                kernel=kernel,
+            )
+
 
 class TestOrthogonalizationPolicy:
     """Test the OrthogonalizationPolicy concrete implementation."""
@@ -351,6 +399,12 @@ class TestOrthogonalizationPolicy:
         assert policy.method == method
         assert policy.n_reortho == n_reortho
         assert policy.n_actions == base_policy.n_actions
+
+    def test_init_errors_on_negative_reorthogonalization(self):
+        """Test n_reortho validation."""
+        base_policy = LanczosPolicy(n_actions=2)
+        with pytest.raises(ValueError, match="n_reortho must be non-negative"):
+            OrthogonalizationPolicy(base_policy=base_policy, n_reortho=-1)
 
     @pytest.mark.parametrize(
         "method,n_reortho",

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -12,8 +12,8 @@ from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
 from cagpjax.linalg import OrthogonalizationMethod
+from cagpjax.interop import lazify
 from cagpjax.operators import BlockDiagonalSparse
-from cagpjax.operators.utils import lazify
 from cagpjax.policies import (
     BlockSparsePolicy,
     LanczosPolicy,

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -24,9 +24,11 @@ from cagpjax.policies import (
 jax.config.update("jax_enable_x64", True)
 
 
-def _test_batch_policy_actions_consistency(policy, op: LinearOperator):
+def _test_batch_policy_actions_consistency(
+    policy, op: LinearOperator, key: jax.Array | None = None
+):
     """Test a batch policy."""
-    actions = policy.to_actions(op)
+    actions = policy.to_actions(op, key=key)
     assert isinstance(actions, LinearOperator)
     assert actions.shape == (op.shape[0], policy.n_actions)
     assert actions.dtype == op.dtype
@@ -44,32 +46,27 @@ def psd_linear_operator(request, key=jax.random.key(42)):
 class TestLanczosPolicy:
     """Test the LanczosPolicy concrete implementation."""
 
-    @pytest.mark.parametrize("key", [None, jax.random.key(42)])
     @pytest.mark.parametrize("n_actions", [2, 4])
-    def test_init_with_valid_params(self, n_actions, key):
+    def test_init_with_valid_params(self, n_actions):
         """Test initialization with valid parameters."""
-        actions = LanczosPolicy(n_actions=n_actions, key=key)
+        actions = LanczosPolicy(n_actions=n_actions)
         assert actions.n_actions == n_actions
-        if key is None:
-            assert actions.key is None
-        else:
-            assert actions.key is not None
-            assert jnp.array_equal(actions.key, key)
 
-    def test_actions_consistency(self, psd_linear_operator, key=jax.random.key(42)):
+    @pytest.mark.parametrize("key", [None, jax.random.key(42)])
+    def test_actions_consistency(self, psd_linear_operator, key):
         """Test that the actions are consistent."""
-        actions = LanczosPolicy(n_actions=2, key=key)
-        _test_batch_policy_actions_consistency(actions, psd_linear_operator)
+        actions = LanczosPolicy(n_actions=2)
+        _test_batch_policy_actions_consistency(actions, psd_linear_operator, key=key)
 
     def test_reproducibility(
         self, psd_linear_operator, n_actions=5, key=jax.random.key(42)
     ):
         """Test that using the same key produces the same results."""
-        actions1 = LanczosPolicy(n_actions=n_actions, key=key)
-        actions2 = LanczosPolicy(n_actions=n_actions, key=key)
+        actions1 = LanczosPolicy(n_actions=n_actions)
+        actions2 = LanczosPolicy(n_actions=n_actions)
 
-        result1 = actions1.to_actions(psd_linear_operator)
-        result2 = actions2.to_actions(psd_linear_operator)
+        result1 = actions1.to_actions(psd_linear_operator, key=key)
+        result2 = actions2.to_actions(psd_linear_operator, key=key)
 
         assert jnp.array_equal(
             result1 @ jnp.eye(n_actions), result2 @ jnp.eye(n_actions)
@@ -90,8 +87,8 @@ class TestLanczosPolicy:
             nvecs_check = 2
 
         # Get eigenvectors using LanczosPolicy
-        actions = LanczosPolicy(n_actions=n_actions, key=key)
-        cg_vecs = actions.to_actions(psd_linear_operator)
+        actions = LanczosPolicy(n_actions=n_actions)
+        cg_vecs = actions.to_actions(psd_linear_operator, key=key)
 
         # Get reference eigenvectors using dense computation
         _, eigenvecs = jnp.linalg.eigh(psd_linear_operator.to_dense())
@@ -117,7 +114,7 @@ class TestLanczosPolicy:
         self, grad_rtol, key, n=10, dtype=jnp.float64
     ):
         """Test that the gradient is zero for a degenerate matrix."""
-        policy = LanczosPolicy(n_actions=n, grad_rtol=grad_rtol, key=key)
+        policy = LanczosPolicy(n_actions=n, grad_rtol=grad_rtol)
         assert policy.grad_rtol == grad_rtol
         x = jnp.ones(n, dtype=dtype)
         scale = jnp.concatenate(
@@ -131,7 +128,7 @@ class TestLanczosPolicy:
         # Increasing grad_rtol should stabilize the gradient.
         def loss(op_diag):
             op = cola.lazify(jnp.diag(op_diag))
-            actions = policy.to_actions(op)
+            actions = policy.to_actions(op, key=key)
             z = actions @ ((actions.T @ x) * scale)
             return jnp.sum(jnp.square(z))
 
@@ -290,7 +287,7 @@ class TestOrthogonalizationPolicy:
     @pytest.mark.parametrize("n_reortho", [0, 1, 2])
     def test_init_and_properties(self, method, n_reortho, key=jax.random.key(42)):
         """Test initialization and basic properties."""
-        base_policy = LanczosPolicy(n_actions=3, key=key)
+        base_policy = LanczosPolicy(n_actions=3)
         policy = OrthogonalizationPolicy(
             base_policy=base_policy, method=method, n_reortho=n_reortho
         )
@@ -354,11 +351,11 @@ class TestOrthogonalizationPolicy:
 
     def test_lanczos_passes_through(self, psd_linear_operator, key=jax.random.key(42)):
         """Test wrapping LanczosPolicy preserves orthogonality."""
-        base_policy = LanczosPolicy(n_actions=3, key=key)
+        base_policy = LanczosPolicy(n_actions=3)
         policy = OrthogonalizationPolicy(base_policy=base_policy)
 
-        base_actions = base_policy.to_actions(psd_linear_operator)
-        ortho_actions = policy.to_actions(psd_linear_operator)
+        base_actions = base_policy.to_actions(psd_linear_operator, key=key)
+        ortho_actions = policy.to_actions(psd_linear_operator, key=key)
 
         assert isinstance(ortho_actions, type(base_actions))
         assert ortho_actions.shape == base_actions.shape

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -8,6 +8,7 @@ import paramax
 import pytest
 from cola.ops import Dense, LinearOperator, Transpose
 from gpjax.dataset import Dataset
+from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
 from cagpjax.linalg import OrthogonalizationMethod
@@ -326,7 +327,11 @@ class TestOrthogonalizationPolicy:
         )
         train_inputs = jax.random.normal(subkey2, (n, input_dim), dtype=dtype)
 
-        kernel = gpjax.kernels.RBF(lengthscale=jnp.ones(input_dim, dtype=dtype))
+        kernel = gpjax.kernels.RBF(
+            lengthscale=Real(jnp.ones(input_dim, dtype=dtype)),
+            variance=Real(jnp.array(1.0, dtype=dtype)),
+            compute_engine=DenseKernelComputation(),
+        )
         base_policy = PseudoInputPolicy(pseudo_inputs, train_inputs, kernel)
         policy = OrthogonalizationPolicy(
             base_policy=base_policy, method=method, n_reortho=n_reortho

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -11,8 +11,8 @@ from gpjax.dataset import Dataset
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
 
-from cagpjax.linalg import OrthogonalizationMethod
 from cagpjax.interop import lazify
+from cagpjax.linalg import OrthogonalizationMethod
 from cagpjax.operators import BlockDiagonalSparse
 from cagpjax.policies import (
     BlockSparsePolicy,
@@ -265,12 +265,11 @@ class TestPseudoInputPolicy:
         train_inputs, pseudo_inputs = inputs
         policy = PseudoInputPolicy(pseudo_inputs, train_inputs, kernel)
         op = lazify(kernel.gram(train_inputs))
+        expected = kernel.cross_covariance(train_inputs, pseudo_inputs)
         actions = policy.to_actions(op)
         assert isinstance(actions, LinearOperator)
         assert actions.dtype == dtype
-        assert jnp.allclose(
-            actions.to_dense(), kernel.cross_covariance(train_inputs, pseudo_inputs)
-        )
+        assert jnp.allclose(actions.to_dense(), expected)
 
     def test_actions_consistency(self, inputs, kernel):
         """Test to_actions consistency and return type."""

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 import paramax
 import pytest
-from cola.ops import Dense, LinearOperator, Transpose
+from cola.ops import Dense, LinearOperator
 from gpjax.dataset import Dataset
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import Real
@@ -43,6 +43,14 @@ def psd_linear_operator(request, key=jax.random.key(42)):
     return cola.PSD(Dense(A))
 
 
+def make_constant_sampler(value):
+    def constant_sampler(key, shape, dtype):
+        del key
+        return jnp.full(shape, value, dtype=dtype)
+
+    return constant_sampler
+
+
 class TestLanczosPolicy:
     """Test the LanczosPolicy concrete implementation."""
 
@@ -52,7 +60,7 @@ class TestLanczosPolicy:
         actions = LanczosPolicy(n_actions=n_actions)
         assert actions.n_actions == n_actions
 
-    @pytest.mark.parametrize("key", [None, jax.random.key(42)])
+    @pytest.mark.parametrize("key", [jax.random.key(42)])
     def test_actions_consistency(self, psd_linear_operator, key):
         """Test that the actions are consistent."""
         actions = LanczosPolicy(n_actions=2)
@@ -145,13 +153,15 @@ class TestLanczosPolicy:
 class TestBlockSparsePolicy:
     """Test the BlockSparsePolicy concrete implementation."""
 
-    @pytest.mark.parametrize("key", [None, jax.random.key(42)])
+    @pytest.mark.parametrize("key", [jax.random.key(42)])
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
     @pytest.mark.parametrize("n_actions", [2, 3])
     @pytest.mark.parametrize("n", [10, 20])
     def test_init_basic(self, n_actions, n, key, dtype):
         """Test basic initialization."""
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy.from_random(
+            key=key, num_datapoints=n, n_actions=n_actions, dtype=dtype
+        )
 
         assert policy.n_actions == n_actions
         assert paramax.unwrap(policy.nz_values).shape == (n,)
@@ -184,7 +194,9 @@ class TestBlockSparsePolicy:
         """Test to_actions consistency and return type."""
         n = psd_linear_operator.shape[0]
         dtype = psd_linear_operator.dtype
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy.from_random(
+            key=key, num_datapoints=n, n_actions=n_actions, dtype=dtype
+        )
         _test_batch_policy_actions_consistency(policy, psd_linear_operator)
         action = policy.to_actions(psd_linear_operator)
         assert isinstance(action, BlockDiagonalSparse)
@@ -196,10 +208,54 @@ class TestBlockSparsePolicy:
         """Test that to_actions produces reproducible results with same values."""
         n = psd_linear_operator.shape[0]
         dtype = psd_linear_operator.dtype
-        policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
+        policy = BlockSparsePolicy.from_random(
+            key=key, num_datapoints=n, n_actions=n_actions, dtype=dtype
+        )
         actions1 = policy.to_actions(psd_linear_operator)
         actions2 = policy.to_actions(psd_linear_operator)
         assert jnp.allclose(actions1.to_dense(), actions2.to_dense())
+
+    @pytest.mark.parametrize("distribution", ["normal", "rademacher", "constant"])
+    def test_from_random_with_distribution_sampler(
+        self,
+        distribution,
+        num_datapoints=12,
+        n_actions=2,
+        dtype=jnp.float64,
+    ):
+        """Test selecting built-in distributions via module-level sampler helper."""
+        if distribution == "normal":
+            sampler = jax.random.normal
+        elif distribution == "rademacher":
+            sampler = jax.random.rademacher
+        elif distribution == "constant":
+            sampler = make_constant_sampler(3.0)
+        else:
+            raise ValueError(f"Invalid distribution: {distribution}")
+
+        policy = BlockSparsePolicy.from_random(
+            key=jax.random.key(13),
+            num_datapoints=num_datapoints,
+            n_actions=n_actions,
+            sampler=sampler,
+            dtype=dtype,
+        )
+        values = paramax.unwrap(policy.nz_values)
+        assert values.shape == (num_datapoints,)
+        assert values.dtype == dtype
+        # confirm values are block-normalized
+        block_size = num_datapoints // n_actions
+        pad_size = num_datapoints - n_actions * block_size
+        padded_values = jnp.concatenate([values, jnp.zeros(pad_size, dtype=dtype)])
+        values_blocked = padded_values.reshape(n_actions, block_size)
+        assert jnp.allclose(jnp.linalg.vector_norm(values_blocked, axis=1), 1.0)
+        # check specific invariants
+        if distribution == "rademacher":
+            block_size = num_datapoints // n_actions
+            scale = 1.0 / jnp.sqrt(block_size).astype(dtype)
+            assert jnp.all(jnp.isin(values, jnp.array([-scale, scale], dtype=dtype)))
+        elif distribution == "constant":
+            assert jnp.all(values == values[0])
 
 
 class TestPseudoInputPolicy:
@@ -365,7 +421,9 @@ class TestOrthogonalizationPolicy:
     ):
         """Test wrapping BlockSparsePolicy preserves orthogonality."""
         n, dtype = psd_linear_operator.shape[0], psd_linear_operator.dtype
-        base_policy = BlockSparsePolicy(n_actions=3, n=n, key=key, dtype=dtype)
+        base_policy = BlockSparsePolicy.from_random(
+            key=key, num_datapoints=n, n_actions=3, dtype=dtype
+        )
         policy = OrthogonalizationPolicy(base_policy=base_policy)
 
         base_actions = base_policy.to_actions(psd_linear_operator)

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -324,7 +324,7 @@ class TestPseudoInputPolicy:
         expected = kernel.cross_covariance(train_inputs, pseudo_inputs)
         actions = policy.to_actions(op)
         assert isinstance(actions, LinearOperator)
-        assert actions.dtype == dtype
+        assert actions.dtype == expected.dtype
         assert jnp.allclose(actions.to_dense(), expected)
 
     def test_actions_consistency(self, inputs, kernel):

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -4,6 +4,7 @@ import cola
 import gpjax.kernels
 import jax
 import jax.numpy as jnp
+import paramax
 import pytest
 from cola.ops import Dense, LinearOperator, Transpose
 from gpjax.dataset import Dataset
@@ -155,9 +156,8 @@ class TestBlockSparsePolicy:
         policy = BlockSparsePolicy(n_actions=n_actions, n=n, key=key, dtype=dtype)
 
         assert policy.n_actions == n_actions
-        assert isinstance(policy.nz_values, Real)
-        assert policy.nz_values.shape == (n,)
-        assert policy.nz_values.dtype == dtype
+        assert paramax.unwrap(policy.nz_values).shape == (n,)
+        assert paramax.unwrap(policy.nz_values).dtype == dtype
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
@@ -170,16 +170,14 @@ class TestBlockSparsePolicy:
 
         policy = BlockSparsePolicy(n_actions=n_actions, nz_values=nz_values)
         assert policy.n_actions == n_actions
-        assert isinstance(policy.nz_values, Real)
-        assert policy.nz_values.dtype == dtype
-        assert jnp.allclose(policy.nz_values[...], nz_values)
+        assert paramax.unwrap(policy.nz_values).dtype == dtype
+        assert jnp.allclose(paramax.unwrap(policy.nz_values), nz_values)
 
         policy_static = BlockSparsePolicy(
-            n_actions=n_actions, nz_values=Real(nz_values)
+            n_actions=n_actions, nz_values=paramax.non_trainable(nz_values)
         )
-        assert isinstance(policy_static.nz_values, Real)
-        assert policy_static.nz_values.dtype == dtype
-        assert jnp.allclose(policy_static.nz_values[...], nz_values)
+        assert jnp.allclose(paramax.unwrap(policy_static.nz_values), nz_values)
+        assert paramax.unwrap(policy_static.nz_values).dtype == dtype
 
     @pytest.mark.parametrize("n_actions", [2, 3])
     def test_to_actions_consistency(
@@ -260,10 +258,9 @@ class TestPseudoInputPolicy:
         assert isinstance(policy, PseudoInputPolicy)
         assert policy.n_actions == pseudo_inputs.shape[0]
         assert policy.kernel is kernel
-        assert isinstance(policy.train_inputs, jnp.ndarray)
-        assert jnp.array_equal(policy.train_inputs, train_inputs)
+        assert jnp.array_equal(paramax.unwrap(policy.train_inputs), train_inputs)
         assert isinstance(policy.pseudo_inputs, pseudo_input_type)
-        assert jnp.array_equal(policy.pseudo_inputs[...], pseudo_inputs)
+        assert jnp.array_equal(paramax.unwrap(policy.pseudo_inputs), pseudo_inputs)
 
     def test_actions_is_cross_covariance(self, inputs, kernel, dtype):
         """Test actions are the cross-covariance between the training inputs and pseudo-inputs."""

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -213,3 +213,37 @@ class TestSolvers:
             assert not jnp.isfinite(grad).all()
         else:
             assert jnp.isfinite(grad).all()
+
+    def test_pseudoinverse_errors_on_negative_tolerances(self):
+        """Test pseudoinverse parameter validation."""
+        with pytest.raises(ValueError, match="rtol must be non-negative"):
+            PseudoInverse(rtol=-1.0)
+        with pytest.raises(ValueError, match="grad_rtol must be non-negative"):
+            PseudoInverse(grad_rtol=-1.0)
+
+    def test_solver_logdet(self, n, dtype, op, op_type):
+        """Test logdet against dense linear algebra."""
+        pseudo_solver = PseudoInverse(rtol=0.0)
+        pseudo_state = pseudo_solver.init(op)
+        pseudo_logdet = pseudo_solver.logdet(pseudo_state)
+        if op_type == "nonsingular":
+            expected_pseudo = jnp.linalg.slogdet(op.to_dense())[1]
+            assert jnp.isclose(pseudo_logdet, expected_pseudo)
+        else:
+            assert jnp.isfinite(pseudo_logdet)
+
+        if dtype == jnp.float32:
+            pytest.skip("Cholesky is not very numerically stable for float32")
+        jitter = 1e-6
+        cholesky_solver = Cholesky(jitter=jitter)
+        cholesky_state = cholesky_solver.init(op)
+        cholesky_logdet = cholesky_solver.logdet(cholesky_state)
+        expected_cholesky = jnp.linalg.slogdet((op + diag_like(op, jitter)).to_dense())[
+            1
+        ]
+        assert jnp.isclose(cholesky_logdet, expected_cholesky)
+
+    def test_cholesky_errors_on_negative_jitter(self):
+        """Test cholesky parameter validation."""
+        with pytest.raises(ValueError, match="jitter must be non-negative"):
+            Cholesky(jitter=-1.0)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -193,7 +193,7 @@ class TestSolvers:
         rtol = (1e-4 if dtype == jnp.float32 else 1e-12) * n
         assert jnp.isclose(trace_solve, trace_solve_solve, rtol=rtol)
 
-    @pytest.mark.parametrize("grad_rtol", [None, -1.0, 0.0])
+    @pytest.mark.parametrize("grad_rtol", [None, 0.0])
     def test_pseudoinverse_gradient_degenerate(self, n, dtype, grad_rtol):
         """Test gradient computation with degenerate operators."""
         A = cola.ops.Dense(jnp.eye(n, dtype=dtype))


### PR DESCRIPTION
GPJax v0.14 replaces flax with equinox and uses paramax and lineax internally. This PR refactors our internals, tests, and examples to follow suit. As a result, this PR is breaking in many ways.

Currently only a release client of GPJax v0.14 has been released. This should not be merged until a final release is available.